### PR TITLE
Vishruth/auto scroll

### DIFF
--- a/freewrite/ContentView.swift
+++ b/freewrite/ContentView.swift
@@ -431,7 +431,7 @@ struct ContentView: View {
                     .frame(maxWidth: 650)
                     
           
-                    .id("\(selectedFont)-\(fontSize)-\(colorScheme)")
+                    .id("\(selectedFont)-\(fontSize)")
                     .padding(.bottom, bottomNavOpacity > 0 ? navHeight : 0)
                     .ignoresSafeArea()
                     .colorScheme(colorScheme)

--- a/freewrite/default.md
+++ b/freewrite/default.md
@@ -35,7 +35,7 @@ That’s it.
 
 Some basic rules:
 
-- Again, no backspaces
+- Again, no backspaces (click on the padlock to toggle strict mode and really enforce this)
 - No fixing spelling
 - Little 5–10s breaks are fine, but try to not stop typing
 - No need to stay on the topic you started with — let your mind wander


### PR DESCRIPTION
Fixes #76 

By removing colorScheme from the .id() modifier, the TextEditor will no longer be completely recreated when switching themes.
