### PR TITLE
fix: auto-scroll issue while toggling dark mode

### DIFF
--- a/freewrite/ContentView.swift
+++ b/freewrite/ContentView.swift
@@ -417,7 +417,7 @@ struct ContentView: View {
                     .frame(maxWidth: 650)
                     
           
-                    .id("\(selectedFont)-\(fontSize)-\(colorScheme)")
+                    .id("\(selectedFont)-\(fontSize)")
                     .padding(.bottom, bottomNavOpacity > 0 ? navHeight : 0)
                     .ignoresSafeArea()
                     .colorScheme(colorScheme)


### PR DESCRIPTION
Fixes #76 

The issue was that the TextEditor's .id() modifier included colorScheme, which caused SwiftUI to recreate the entire TextEditor view whenever you switched themes. Now it only recreates when the font or font size changes, preserving your scroll position during theme switches.