### PR TITLE
Use fixed 18pt editor inset instead of centered 650px column

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,56 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+# Freewrite is a native macOS SwiftUI app (Xcode/Swift, no package manager).
+# Entries live in ~/Documents/Freewrite/ and preferences use
+# app.humansongs.freewrite UserDefaults, so only one launched app at a time.
+
+[scripts]
+setup = """
+set -euo pipefail
+if [ "${CONDUCTOR_IS_LOCAL:-1}" != "1" ]; then
+  echo "Skipping freewrite setup (requires local Xcode on macOS)."
+  exit 0
+fi
+command -v xcodebuild >/dev/null
+xcodebuild -version
+xcodebuild -list -project freewrite.xcodeproj
+"""
+run_mode = "nonconcurrent"
+archive = """
+set -euo pipefail
+DERIVED_DATA="${TMPDIR%/}/conductor-freewrite-${CONDUCTOR_WORKSPACE_NAME:-workspace}"
+APP_BIN="$DERIVED_DATA/Build/Products/Debug/freewrite.app/Contents/MacOS/freewrite"
+if [ -x "$APP_BIN" ]; then
+  pkill -f "$APP_BIN" 2>/dev/null || true
+fi
+rm -rf "$DERIVED_DATA"
+"""
+
+[scripts.run.app]
+command = """
+set -euo pipefail
+DERIVED_DATA="${TMPDIR%/}/conductor-freewrite-${CONDUCTOR_WORKSPACE_NAME:-workspace}"
+xcodebuild -project freewrite.xcodeproj -scheme freewrite -configuration Debug -destination 'platform=macOS' -derivedDataPath "$DERIVED_DATA" build
+exec "$DERIVED_DATA/Build/Products/Debug/freewrite.app/Contents/MacOS/freewrite"
+"""
+default = true
+icon = "play"
+available_in = ["local"]
+
+[scripts.run.build]
+command = """
+set -euo pipefail
+DERIVED_DATA="${TMPDIR%/}/conductor-freewrite-${CONDUCTOR_WORKSPACE_NAME:-workspace}"
+xcodebuild -project freewrite.xcodeproj -scheme freewrite -configuration Debug -destination 'platform=macOS' -derivedDataPath "$DERIVED_DATA" build
+"""
+icon = "hammer"
+available_in = ["local"]
+
+[scripts.run.test]
+command = """
+set -euo pipefail
+DERIVED_DATA="${TMPDIR%/}/conductor-freewrite-${CONDUCTOR_WORKSPACE_NAME:-workspace}"
+xcodebuild -project freewrite.xcodeproj -scheme freewrite -destination 'platform=macOS' -derivedDataPath "$DERIVED_DATA" test -only-testing:freewriteTests
+"""
+icon = "test-tube"
+available_in = ["local"]

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,14 @@ playground.xcworkspace
 
 # Icon?
 Icon?
+
+# Agent tooling (local)
+.agents/
+.claude/
+.codex/
+.cursor/
+.gemini/
+.grok/
+.pi/
+.opencode/
+.impeccable/

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,21 @@
+## Design Context
+
+### Users
+Distraction-free writers and journalers who want to capture thoughts the moment they happen, without ceremony. They free-write, record short video thoughts, and revisit entries later — often in quiet or late-night moments, in flow. The tool should stay out of the way so the thinking stays theirs.
+
+### Brand Personality
+Fast, light, frictionless. Calm, minimal, human. The voice is a friend, not a tool or a therapist — warm, direct, slightly casual, never clinical, never corporate. The interface is quiet and nearly invisible so the writing is the only thing on screen.
+
+### Aesthetic Direction
+Minimal and calm by default — the UI's job is to disappear during timed writing sessions, leaving only the text (or video). No dense panels, no feature-soup chrome, nothing that reads as default/stock.
+
+- Theme: both light and dark, user-switchable and persisted; neither is the "default default."
+- Anti-references: not a cluttered Notion-style tool; not generic Notes.app; not a slick dark developer tool.
+- Native SwiftUI/macOS app — design must feel at home on the platform, not like a ported web UI.
+
+### Design Principles
+- **Get out of the way.** The interface's job is to disappear. Most UI hides during timed sessions; the text (or video) is the whole point.
+- **Practice what you preach.** The app itself should feel as frictionless as the writing it enables — no dialogs, no setup, auto-everything.
+- **Start instantly.** Open the app and you're already writing today's entry; no blank "new document" gate.
+- **Human over clinical.** Tone and detail should read as a friend's helping hand — comfort, validation, warmth — not a sterile product.
+- **Local-first ownership.** Every thought lives in a plain file the user can open; transparency and control over cleverness.

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,96 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-05T14:21:50Z",
+  "title": "Design System: Freewrite",
+  "extensions": {
+    "colorMeta": {
+      "ink": { "role": "primary", "displayName": "Soft Off-Black", "canonical": "#333333", "tonalRamp": ["#1a1a1a", "#242424", "#2e2e2e", "#333333", "#4d4d4d", "#666666", "#808080", "#999999"] },
+      "ink-soft": { "role": "neutral", "displayName": "Soft Off-White", "canonical": "#E6E6E6", "tonalRamp": ["#4d4d4d", "#6b6b6b", "#8a8a8a", "#a8a8a8", "#c7c7c7", "#d6d6d6", "#e6e6e6", "#f2f2f2"] },
+      "ink-muted": { "role": "neutral", "displayName": "Muted Gray", "canonical": "#808080", "tonalRamp": ["#404040", "#555555", "#6a6a6a", "#808080", "#959595", "#aaaaaa", "#bfbfbf", "#d4d4d4"] },
+      "paper": { "role": "neutral", "displayName": "Paper White", "canonical": "#FFFFFF", "tonalRamp": ["#666666", "#8a8a8a", "#adadad", "#d1d1d1", "#e6e6e6", "#f2f2f2", "#fafafa", "#ffffff"] },
+      "night": { "role": "neutral", "displayName": "Night", "canonical": "#000000", "tonalRamp": ["#000000", "#1a1a1a", "#333333", "#4d4d4d", "#666666", "#808080", "#999999", "#b3b3b3"] },
+      "row-selected": { "role": "neutral", "displayName": "Row Selected", "canonical": "rgba(128,128,128,0.10)", "tonalRamp": ["#e0e0e0", "#d9d9d9", "#d2d2d2", "#cccccc", "#c5c5c5", "#bfbfbf", "#b8b8b8", "#b2b2b2"] },
+      "row-hover": { "role": "neutral", "displayName": "Row Hover", "canonical": "rgba(128,128,128,0.05)", "tonalRamp": ["#efefef", "#ececec", "#e9e9e9", "#e6e6e6", "#e3e3e3", "#e0e0e0", "#dddddd", "#dadada"] },
+      "placeholder": { "role": "neutral", "displayName": "Placeholder Gray", "canonical": "rgba(128,128,128,0.50)", "tonalRamp": ["#bfbfbf", "#c7c7c7", "#cfcfcf", "#d7d7d7", "#dfdfdf", "#e7e7e7", "#efefef", "#f7f7f7"] }
+    },
+    "typographyMeta": {
+      "body": { "displayName": "Body", "purpose": "The writing surface. 18px default, 16-26px adjustable, 1.5x line height, 650px measure." },
+      "label": { "displayName": "Label", "purpose": "Navigation controls and entry previews (13px)." },
+      "label-small": { "displayName": "Label Small", "purpose": "Entry dates and secondary metadata (12px)." }
+    },
+    "shadows": [
+      { "name": "menu-float", "value": "rgba(0,0,0,0.10) 0px 2px 4px", "purpose": "The single shadow in the system; reserved for floating popovers only." }
+    ],
+    "motion": [
+      { "name": "ease-standard", "value": "ease-in-out 0.2s", "purpose": "Default for state transitions (nav fade, sidebar slide, hover)." },
+      { "name": "ease-reveal", "value": "ease-in 1.0s", "purpose": "Slow fade-out of the nav during timed focus sessions." }
+    ],
+    "breakpoints": []
+  },
+  "components": [
+    {
+      "name": "Navigation Button",
+      "kind": "button",
+      "refersTo": "nav-button",
+      "description": "Quiet text button in the bottom nav; gray at rest, darkens on hover.",
+      "html": "<button class=\"ds-nav\">15:00</button>",
+      "css": ".ds-nav { background: transparent; border: none; color: #808080; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; padding: 8px; border-radius: 8px; cursor: pointer; transition: color 0.2s ease-in-out; } .ds-nav:hover { color: #333333; }"
+    },
+    {
+      "name": "Sidebar Row (rest)",
+      "kind": "nav",
+      "refersTo": "sidebar-row",
+      "description": "History entry row at rest; no fill, 4px radius.",
+      "html": "<div class=\"ds-row\"><span class=\"ds-row-preview\">This is my first entry...</span><span class=\"ds-row-date\">Aug 4</span></div>",
+      "css": ".ds-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; height: 40px; padding: 8px 16px; border-radius: 4px; cursor: pointer; } .ds-row-preview { color: #333333; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; } .ds-row-date { color: #808080; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 12px; } .ds-row:hover { background: rgba(128,128,128,0.05); }"
+    },
+    {
+      "name": "Sidebar Row (selected)",
+      "kind": "nav",
+      "refersTo": "sidebar-row-selected",
+      "description": "History row when the entry is active; whisper-gray fill.",
+      "html": "<div class=\"ds-row ds-row-selected\"><span class=\"ds-row-preview\">Today's thoughts</span><span class=\"ds-row-date\">Aug 5</span></div>",
+      "css": ".ds-row-selected { background: rgba(128,128,128,0.10); } .ds-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; height: 40px; padding: 8px 16px; border-radius: 4px; } .ds-row-preview { color: #333333; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; } .ds-row-date { color: #808080; font-family: -apple-system, BlinkMacSystemFont, sans-serif; font-size: 12px; }"
+    },
+    {
+      "name": "Editor Placeholder",
+      "kind": "custom",
+      "refersTo": "editor",
+      "description": "Empty writing surface showing a faint placeholder hint.",
+      "html": "<div class=\"ds-editor\"><span class=\"ds-ph\">Begin writing</span></div>",
+      "css": ".ds-editor { background: #ffffff; width: 650px; padding-top: 40px; } .ds-ph { color: rgba(128,128,128,0.50); font-family: Lato, -apple-system, sans-serif; font-size: 18px; line-height: 1.5; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Quiet Page",
+    "overview": "Freewrite's visual system is built to vanish. The product is a distraction-free writing environment — the point is that nothing on screen competes with the words (or the video) being captured. The interface reads as a nearly empty page: white in light mode, black in dark mode, with typography and whitespace carrying all the identity. There is no accent color; there is no decorative chrome; there is no competing structure. Calm, minimal, and human — the design whispers so the writing can speak. Density is deliberately low. The editor is capped at a comfortable measure (650px) so long-form thought never feels crowded. The bottom navigation is a quiet strip of gray text that darkens on hover and recedes entirely during focused timed sessions. Surfaces are flat at rest; the only depth is a whisper of shadow on popovers, and it appears only when a menu must float above the page. This system explicitly rejects the cluttered Notion-style tool and the generic Notes.app. It is a friend's quiet desk, not a control room.",
+    "keyCharacteristics": [
+      "Ink-only. No color beyond black/white/gray; identity lives in typography and whitespace.",
+      "Flat by default; depth reserved for floating menus only.",
+      "Human-calm microcopy and a sparse, unpressured layout.",
+      "Native macOS restraint — it should feel at home on the platform, never like a ported web UI.",
+      "The interface's highest goal is to disappear during writing."
+    ],
+    "rules": [
+      { "name": "The One Ink Rule", "body": "There is exactly one ink family. Any color that isn't black, white, gray, or a transparency of those is forbidden.", "section": "colors" },
+      { "name": "The One Voice Rule", "body": "Every font is an option the writer chooses for their own words (Lato, Arial, System, Serif, or random). The system chrome itself always speaks in the native system sans — the tool's voice stays distinct from the writer's.", "section": "typography" },
+      { "name": "The Flat-By-Default Rule", "body": "Surfaces are flat at rest. Shadows appear only to lift a floating menu off the page — never as card decoration, never on the writing surface itself.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do keep the writing surface utterly bare — no borders, frames, shadows, or background tint on the editor.",
+      "Do use the soft ink values (#333333 light / #E6E6E6 dark) for body text over the muted gray; never read near-ink against a tinted background.",
+      "Do reserve the single Menu Float shadow for popovers only.",
+      "Do keep selection and hover states whisper-subtle (gray at 10% / 5%).",
+      "Do protect the 650px measure and 1.5× line height for long-session comfort.",
+      "Do let the interface recede during timed writing — hiding the nav is a feature, not a bug."
+    ],
+    "donts": [
+      "Don't introduce any accent or brand color — this is strictly monochrome (ink-only).",
+      "Don't build a cluttered Notion-style tool — no dense panels, nested database chrome, or feature-soup navigation.",
+      "Don't ship generic Notes.app blandness — every detail must feel considered, not default.",
+      "Don't go dark \"developer-tool\" — no terminal green/amber, no neon, no glassmorphism.",
+      "Don't add card shadows, gradient text, side-stripe colored borders, or oversized radii (≥16px) anywhere.",
+      "Don't gate content visibility behind a hover or reveal state — what matters must be visible by default."
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -793,7 +793,7 @@ func exportEntryAsPDF(entry: HumanEntry) {
 ```
 
 **Title Extraction**:
-- Takes first 4 words of content
+- Takes first 4 words of the first line of content
 - Removes punctuation
 - Falls back to "Entry [date]" if content empty
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -988,3 +988,32 @@ When making changes, always:
 - Check for collection mutation crashes
 - Verify files are created in correct location
 - Ensure privacy permissions are properly configured
+
+## Design Context
+
+Design direction is captured in `PRODUCT.md`, `DESIGN.md`, and `.impeccable.md`. The visual system ("The Quiet Page") is **strictly monochrome, ink-only** — identity lives in typography and whitespace, never in accent color.
+
+### Users
+Distraction-free writers and journalers who want to capture thoughts the moment they happen, without ceremony. They free-write, record short video thoughts, and revisit entries later — often in quiet or late-night moments, in flow. The tool should stay out of the way so the thinking stays theirs.
+
+### Brand Personality
+Fast, light, frictionless. Calm, minimal, human. The voice is a friend, not a tool or a therapist — warm, direct, slightly casual, never clinical, never corporate. The interface is quiet and nearly invisible so the writing is the only thing on screen.
+
+### Aesthetic Direction
+Minimal and calm by default — the UI's job is to disappear during timed writing sessions, leaving only the text (or video). No dense panels, no feature-soup chrome, nothing that reads as default/stock.
+- Theme: both light and dark, user-switchable and persisted; neither is the "default default."
+- Anti-references: not a cluttered Notion-style tool; not generic Notes.app; not a slick dark developer tool.
+- Native SwiftUI/macOS app — design must feel at home on the platform, not like a ported web UI.
+
+### Design Principles
+- **Get out of the way.** The interface's job is to disappear. Most UI hides during timed sessions; the text (or video) is the whole point.
+- **Practice what you preach.** The app itself should feel as frictionless as the writing it enables — no dialogs, no setup, auto-everything.
+- **Start instantly.** Open the app and you're already writing today's entry; no blank "new document" gate.
+- **Human over clinical.** Tone and detail should read as a friend's helping hand — comfort, validation, warmth — not a sterile product.
+- **Local-first ownership.** Every thought lives in a plain file the user can open; transparency and control over cleverness.
+
+### Visual Guardrails (from DESIGN.md)
+- **The One Ink Rule.** No accent or brand color, ever — strictly black / white / gray / their transparencies.
+- **The Flat-By-Default Rule.** Flat surfaces; one whisper shadow (`rgba(0,0,0,0.10)` @ 4px) reserved for floating popovers only.
+- **The One Voice Rule.** System chrome always speaks in the native system sans; the writer's words may use Lato / Arial / System / Serif / random.
+- Body ink: `#333333` (light) / `#E6E6E6` (dark). Selection/hover fills: gray at 10% / 5%. Editor measure 650px, 1.5× line height.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -995,4 +995,4 @@ Minimal and calm by default — the UI's job is to disappear during timed writin
 - **The One Ink Rule.** No accent or brand color, ever — strictly black / white / gray / their transparencies.
 - **The Flat-By-Default Rule.** Flat surfaces; one whisper shadow (`rgba(0,0,0,0.10)` @ 4px) reserved for floating popovers only.
 - **The One Voice Rule.** System chrome always speaks in the native system sans; the writer's words may use Lato / Arial / System / Serif / random.
-- Body ink: `#333333` (light) / `#E6E6E6` (dark). Selection/hover fills: gray at 10% / 5%. Editor measure 650px, 1.5× line height.
+- Body ink: `#333333` (light) / `#E6E6E6` (dark). Selection/hover fills: gray at 10% / 5%. Editor fills the window with a fixed 18px inset on all four sides, 1.5× line height.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,6 @@ Freewrite is a **distraction-free writing environment** for macOS designed aroun
 
 **Hidden Power Feature - Long-Form Writing:**
 - Despite minimalist interface, supports full markdown
-- Entries can be exported as PDFs
 - Font and size customization for comfort during long sessions
 - Dark mode for night writing
 
@@ -776,26 +775,6 @@ if let encodedText = fullText.addingPercentEncoding(withAllowedCharacters: .urlQ
 - URLs >6000 chars fail in some browsers
 - If too long, shows "Copy Prompt" button instead
 - Copies to clipboard for manual paste
-
-### PDF Export Implementation
-
-```swift
-func exportEntryAsPDF(entry: HumanEntry) {
-    let savePanel = NSSavePanel()
-    savePanel.title = extractTitleFromContent(content, date: entry.date)
-    savePanel.allowedContentTypes = [.pdf]
-
-    if savePanel.runModal() == .OK {
-        let pdfData = createPDF(from: content)
-        try pdfData.write(to: savePanel.url!)
-    }
-}
-```
-
-**Title Extraction**:
-- Takes first 4 words of the first line of content
-- Removes punctuation
-- Falls back to "Entry [date]" if content empty
 
 ### Theme System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -793,7 +793,7 @@ func exportEntryAsPDF(entry: HumanEntry) {
 ```
 
 **Title Extraction**:
-- Takes first 4 words of content
+- Takes first 4 words of the first line of content
 - Removes punctuation
 - Falls back to "Entry [date]" if content empty
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -988,3 +988,32 @@ When making changes, always:
 - Check for collection mutation crashes
 - Verify files are created in correct location
 - Ensure privacy permissions are properly configured
+
+## Design Context
+
+Design direction is captured in `PRODUCT.md`, `DESIGN.md`, and `.impeccable.md`. The visual system ("The Quiet Page") is **strictly monochrome, ink-only** — identity lives in typography and whitespace, never in accent color.
+
+### Users
+Distraction-free writers and journalers who want to capture thoughts the moment they happen, without ceremony. They free-write, record short video thoughts, and revisit entries later — often in quiet or late-night moments, in flow. The tool should stay out of the way so the thinking stays theirs.
+
+### Brand Personality
+Fast, light, frictionless. Calm, minimal, human. The voice is a friend, not a tool or a therapist — warm, direct, slightly casual, never clinical, never corporate. The interface is quiet and nearly invisible so the writing is the only thing on screen.
+
+### Aesthetic Direction
+Minimal and calm by default — the UI's job is to disappear during timed writing sessions, leaving only the text (or video). No dense panels, no feature-soup chrome, nothing that reads as default/stock.
+- Theme: both light and dark, user-switchable and persisted; neither is the "default default."
+- Anti-references: not a cluttered Notion-style tool; not generic Notes.app; not a slick dark developer tool.
+- Native SwiftUI/macOS app — design must feel at home on the platform, not like a ported web UI.
+
+### Design Principles
+- **Get out of the way.** The interface's job is to disappear. Most UI hides during timed sessions; the text (or video) is the whole point.
+- **Practice what you preach.** The app itself should feel as frictionless as the writing it enables — no dialogs, no setup, auto-everything.
+- **Start instantly.** Open the app and you're already writing today's entry; no blank "new document" gate.
+- **Human over clinical.** Tone and detail should read as a friend's helping hand — comfort, validation, warmth — not a sterile product.
+- **Local-first ownership.** Every thought lives in a plain file the user can open; transparency and control over cleverness.
+
+### Visual Guardrails (from DESIGN.md)
+- **The One Ink Rule.** No accent or brand color, ever — strictly black / white / gray / their transparencies.
+- **The Flat-By-Default Rule.** Flat surfaces; one whisper shadow (`rgba(0,0,0,0.10)` @ 4px) reserved for floating popovers only.
+- **The One Voice Rule.** System chrome always speaks in the native system sans; the writer's words may use Lato / Arial / System / Serif / random.
+- Body ink: `#333333` (light) / `#E6E6E6` (dark). Selection/hover fills: gray at 10% / 5%. Editor measure 650px, 1.5× line height.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -995,4 +995,4 @@ Minimal and calm by default — the UI's job is to disappear during timed writin
 - **The One Ink Rule.** No accent or brand color, ever — strictly black / white / gray / their transparencies.
 - **The Flat-By-Default Rule.** Flat surfaces; one whisper shadow (`rgba(0,0,0,0.10)` @ 4px) reserved for floating popovers only.
 - **The One Voice Rule.** System chrome always speaks in the native system sans; the writer's words may use Lato / Arial / System / Serif / random.
-- Body ink: `#333333` (light) / `#E6E6E6` (dark). Selection/hover fills: gray at 10% / 5%. Editor measure 650px, 1.5× line height.
+- Body ink: `#333333` (light) / `#E6E6E6` (dark). Selection/hover fills: gray at 10% / 5%. Editor fills the window with a fixed 18px inset on all four sides, 1.5× line height.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,6 @@ Freewrite is a **distraction-free writing environment** for macOS designed aroun
 
 **Hidden Power Feature - Long-Form Writing:**
 - Despite minimalist interface, supports full markdown
-- Entries can be exported as PDFs
 - Font and size customization for comfort during long sessions
 - Dark mode for night writing
 
@@ -776,26 +775,6 @@ if let encodedText = fullText.addingPercentEncoding(withAllowedCharacters: .urlQ
 - URLs >6000 chars fail in some browsers
 - If too long, shows "Copy Prompt" button instead
 - Copies to clipboard for manual paste
-
-### PDF Export Implementation
-
-```swift
-func exportEntryAsPDF(entry: HumanEntry) {
-    let savePanel = NSSavePanel()
-    savePanel.title = extractTitleFromContent(content, date: entry.date)
-    savePanel.allowedContentTypes = [.pdf]
-
-    if savePanel.runModal() == .OK {
-        let pdfData = createPDF(from: content)
-        try pdfData.write(to: savePanel.url!)
-    }
-}
-```
-
-**Title Extraction**:
-- Takes first 4 words of the first line of content
-- Removes punctuation
-- Falls back to "Entry [date]" if content empty
 
 ### Theme System
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -144,7 +144,7 @@ Flat by default. The system conveys hierarchy through ink weight and tonal layer
 - **Shape:** Gently curved (4px radius), full-width.
 - **Background:** Clear at rest; Row Hover (gray/5%) on hover; Row Selected (gray/10%) when active.
 - **Content:** Entry preview (13px) + date (12px) stacked; video entries show a 40px rounded thumbnail with a play overlay.
-- **Hover Actions:** Export (PDF) and trash icons fade in on hover, right-aligned; trash turns red on hover.
+- **Hover Actions:** Trash icon fades in on hover, right-aligned; turns red on hover.
 - **Shadow:** None.
 
 ### Editor

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -16,7 +16,7 @@ typography:
     fontSize: "18px"
     fontWeight: 400
     lineHeight: 1.5
-    maxWidth: "650px"
+    inset: "18px"
   label:
     fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif"
     fontSize: "13px"
@@ -64,7 +64,7 @@ components:
     backgroundColor: "{colors.paper}"
     textColor: "{colors.ink}"
     typography: "{typography.body}"
-    width: "650px"
+    inset: "18px"
 ---
 
 # Design System: Freewrite
@@ -75,7 +75,7 @@ components:
 
 Freewrite's visual system is built to vanish. The product is a distraction-free writing environment — the point is that nothing on screen competes with the words (or the video) being captured. The interface reads as a nearly empty page: white in light mode, black in dark mode, with typography and whitespace carrying all the identity. There is no accent color; there is no decorative chrome; there is no competing structure. Calm, minimal, and human — the design whispers so the writing can speak.
 
-Density is deliberately low. The editor is capped at a comfortable measure (650px) so long-form thought never feels crowded. The bottom navigation is a quiet strip of gray text that darkens on hover and recedes entirely during focused timed sessions. Surfaces are flat at rest; the only depth is a whisper of shadow on popovers, and it appears only when a menu must float above the page.
+Density is deliberately low. The editor fills the window behind a fixed 18px inset on all four sides, so the page feels open at any window size. The bottom navigation is a quiet strip of gray text that darkens on hover and recedes entirely during focused timed sessions. Surfaces are flat at rest; the only depth is a whisper of shadow on popovers, and it appears only when a menu must float above the page.
 
 This system explicitly rejects the cluttered Notion-style tool (dense panels, nested databases, feature-soup chrome) and the generic Notes.app (stock memo-list blandness). It equally rejects the slick dark developer tool. It is a friend's quiet desk, not a control room.
 
@@ -110,10 +110,10 @@ A strict monochrome ramp. Identity is carried by ink and paper, never by hue. Tw
 **Body Font:** Lato (fallback: system sans)
 **Label Font:** System (Apple SF)
 
-**Character:** A calm, humanist pairing. Lato at a generous 1.5× line height creates easy vertical rhythm for long writing sessions; the compact system sans keeps the navigation quiet and unobtrusive. The measure is capped at 650px to protect comfortable reading.
+**Character:** A calm, humanist pairing. Lato at a generous 1.5× line height creates easy vertical rhythm for long writing sessions; the compact system sans keeps the navigation quiet and unobtrusive. A fixed 18px page inset keeps the text off the window edges.
 
 ### Hierarchy
-- **Body** (regular, 18px, 1.5× line height): The core surface — the user's writing. Adjustable from 16–26px with 1.5× line height preserved. Max width 650px.
+- **Body** (regular, 18px, 1.5× line height): The core surface — the user's writing. Adjustable from 16–26px with 1.5× line height preserved. Full window width, inset 18px on all four sides.
 - **Label** (regular, 13px): Navigation controls, sidebar entry previews, action buttons.
 - **Label Small** (regular, 12px): Entry dates, secondary sidebar metadata, popover sublabels.
 - **Display/Headline**: Intentionally absent. A writing tool has no hero headings; the writing is the only "display."
@@ -148,7 +148,7 @@ Flat by default. The system conveys hierarchy through ink weight and tonal layer
 - **Shadow:** None.
 
 ### Editor
-- **Style:** Borderless and backgroundless text, transparent scrollbars, centered measure of 650px, 40px top breathing room.
+- **Style:** Borderless and backgroundless text, transparent scrollbars, full-bleed page with a fixed 18px inset on all four sides.
 - **Focus:** None — it is always focused by design; there is no frame or glow to signal editing.
 - **Placeholder:** Faint Placeholder Gray hint in the empty state, removed the instant the writer types.
 
@@ -170,7 +170,7 @@ Flat by default. The system conveys hierarchy through ink weight and tonal layer
 - **Do** use the soft ink values (#333333 light / #E6E6E6 dark) for body text over the muted gray; never read near-ink against a tinted background.
 - **Do** reserve the single Menu Float shadow for popovers only.
 - **Do** keep selection and hover states whisper-subtle (gray at 10% / 5%).
-- **Do** protect the 650px measure and 1.5× line height for long-session comfort.
+- **Do** protect the fixed 18px page inset and 1.5× line height for long-session comfort.
 - **Do** let the interface recede during timed writing — hiding the nav is a feature, not a bug.
 
 ### Don't:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,182 @@
+---
+name: Freewrite
+description: A distraction-free, local-first writing and video journaling app for macOS.
+colors:
+  ink: "#333333"
+  ink-soft: "#E6E6E6"
+  ink-muted: "#808080"
+  paper: "#FFFFFF"
+  night: "#000000"
+  row-selected: "rgba(128,128,128,0.10)"
+  row-hover: "rgba(128,128,128,0.05)"
+  placeholder: "rgba(128,128,128,0.50)"
+typography:
+  body:
+    fontFamily: "Lato, Lato-Regular, -apple-system, sans-serif"
+    fontSize: "18px"
+    fontWeight: 400
+    lineHeight: 1.5
+    maxWidth: "650px"
+  label:
+    fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: "13px"
+    fontWeight: 400
+  label-small:
+    fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: "12px"
+    fontWeight: 400
+rounded:
+  sm: "4px"
+  md: "8px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "16px"
+components:
+  nav-button:
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.label}"
+    rounded: "{rounded.md}"
+    padding: "8px"
+  nav-button-hover:
+    textColor: "{colors.ink}"
+    typography: "{typography.label}"
+    rounded: "{rounded.md}"
+    padding: "8px"
+  sidebar-row:
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+    height: "40px"
+    padding: "8px 16px"
+  sidebar-row-selected:
+    backgroundColor: "{colors.row-selected}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+    height: "40px"
+    padding: "8px 16px"
+  sidebar-row-hover:
+    backgroundColor: "{colors.row-hover}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+    height: "40px"
+    padding: "8px 16px"
+  editor:
+    backgroundColor: "{colors.paper}"
+    textColor: "{colors.ink}"
+    typography: "{typography.body}"
+    width: "650px"
+---
+
+# Design System: Freewrite
+
+## 1. Overview
+
+**Creative North Star: "The Quiet Page"**
+
+Freewrite's visual system is built to vanish. The product is a distraction-free writing environment — the point is that nothing on screen competes with the words (or the video) being captured. The interface reads as a nearly empty page: white in light mode, black in dark mode, with typography and whitespace carrying all the identity. There is no accent color; there is no decorative chrome; there is no competing structure. Calm, minimal, and human — the design whispers so the writing can speak.
+
+Density is deliberately low. The editor is capped at a comfortable measure (650px) so long-form thought never feels crowded. The bottom navigation is a quiet strip of gray text that darkens on hover and recedes entirely during focused timed sessions. Surfaces are flat at rest; the only depth is a whisper of shadow on popovers, and it appears only when a menu must float above the page.
+
+This system explicitly rejects the cluttered Notion-style tool (dense panels, nested databases, feature-soup chrome) and the generic Notes.app (stock memo-list blandness). It equally rejects the slick dark developer tool. It is a friend's quiet desk, not a control room.
+
+**Key Characteristics:**
+- Ink-only. No color beyond black/white/gray; identity lives in typography and whitespace.
+- Flat by default; depth reserved for floating menus only.
+- Human-calm microcopy and a sparse, unpressured layout.
+- Native macOS restraint — it should feel at home on the platform, never like a ported web UI.
+- The interface's highest goal is to disappear during writing.
+
+## 2. Colors
+
+A strict monochrome ramp. Identity is carried by ink and paper, never by hue. Two themes mirror each other: light (paper + soft off-black ink) and dark (night + soft off-white ink).
+
+### Primary
+- **Soft Off-Black** (#333333): The primary ink for body text in light mode. A softened near-black chosen for comfortable long-session reading — easier on the eyes than pure black.
+
+### Neutral
+- **Paper White** (#FFFFFF): The light-mode surface and editor background. Pure and untextured; the page the user writes on.
+- **Night** (#000000): The dark-mode surface. True black that lets the writing and video recede into a quiet frame.
+- **Soft Off-White** (#E6E6E6): Body text in dark mode. An eased white for comfortable reading against night.
+- **Muted Gray** (#808080): Resting state for navigation labels, dates, and secondary information. Darkens to ink on hover.
+- **Placeholder Gray** (#808080 at 50%): The empty-editor hint ("Begin writing"), deliberately faint so it never competes with real words.
+- **Row Selected** (#808080 at 10%): The selected entry's background in the history sidebar.
+- **Row Hover** (#808080 at 5%): The hover background for sidebar rows — nearly imperceptible, always calm.
+
+### Named Rules
+**The One Ink Rule.** There is exactly one ink family. Any color that isn't black, white, gray, or a transparency of those is forbidden. Rarity of any accent is moot — there simply is none.
+
+## 3. Typography
+
+**Body Font:** Lato (fallback: system sans)
+**Label Font:** System (Apple SF)
+
+**Character:** A calm, humanist pairing. Lato at a generous 1.5× line height creates easy vertical rhythm for long writing sessions; the compact system sans keeps the navigation quiet and unobtrusive. The measure is capped at 650px to protect comfortable reading.
+
+### Hierarchy
+- **Body** (regular, 18px, 1.5× line height): The core surface — the user's writing. Adjustable from 16–26px with 1.5× line height preserved. Max width 650px.
+- **Label** (regular, 13px): Navigation controls, sidebar entry previews, action buttons.
+- **Label Small** (regular, 12px): Entry dates, secondary sidebar metadata, popover sublabels.
+- **Display/Headline**: Intentionally absent. A writing tool has no hero headings; the writing is the only "display."
+
+### Named Rules
+**The One Voice Rule.** Every font is an option the *writer* chooses for their own words (Lato, Arial, System, Serif, or random). The system chrome itself always speaks in the native system sans — the tool's voice stays distinct from the writer's.
+
+## 4. Elevation
+
+Flat by default. The system conveys hierarchy through ink weight and tonal layering (selection fills, divider lines), not through shadows. Depth appears in exactly one place: floating menus (popovers), which need to read as sitting above the page.
+
+### Shadow Vocabulary
+- **Menu Float** (`rgba(0,0,0,0.10)` at 4px, 2px offset): The single shadow in the system, reserved for popovers and dropdowns. Ambient, whisper-level, never structural.
+
+### Named Rules
+**The Flat-By-Default Rule.** Surfaces are flat at rest. Shadows appear only to lift a floating menu off the page — never as card decoration, never on the writing surface itself.
+
+## 5. Components
+
+### Buttons (Navigation & Actions)
+- **Shape:** Invisible until hover — plain text, no border, no background.
+- **Resting:** Muted Gray text (12–13px). Clickable affordance shown only by the pointer cursor.
+- **Hover:** Darkens to the ink (Soft Off-Black in light mode, Soft Off-White in dark mode); pointer becomes the pointing hand.
+- **Primary:** N/A. There are no filled action buttons; the app's whole posture is to avoid visual weight.
+- **Separators:** Items in the bottom nav are divided by a single muted gray dot (`•`) — not pipes or rules, keeping the strip airy.
+
+### History Sidebar Rows
+- **Shape:** Gently curved (4px radius), full-width.
+- **Background:** Clear at rest; Row Hover (gray/5%) on hover; Row Selected (gray/10%) when active.
+- **Content:** Entry preview (13px) + date (12px) stacked; video entries show a 40px rounded thumbnail with a play overlay.
+- **Hover Actions:** Export (PDF) and trash icons fade in on hover, right-aligned; trash turns red on hover.
+- **Shadow:** None.
+
+### Editor
+- **Style:** Borderless and backgroundless text, transparent scrollbars, centered measure of 650px, 40px top breathing room.
+- **Focus:** None — it is always focused by design; there is no frame or glow to signal editing.
+- **Placeholder:** Faint Placeholder Gray hint in the empty state, removed the instant the writer types.
+
+### Inputs / Fields
+- **Style:** None present — the app avoids form-like inputs entirely in its core loop.
+
+### Navigation (Bottom Bar)
+- **Style:** A flat strip (68px) at the bottom of the window, transparent over video, content-matched background elsewhere.
+- **State:** During a timed session it fades out after a moment and reappears on hover; when idle it stays at full opacity.
+- **Treatment:** Gray text labels and icons separated by muted dots; each darkens on hover.
+
+### Video Player
+- **Style:** Standard AVKit controls. The player surface fills the content area with no chrome, so the recording is the whole experience.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** keep the writing surface utterly bare — no borders, frames, shadows, or background tint on the editor.
+- **Do** use the soft ink values (#333333 light / #E6E6E6 dark) for body text over the muted gray; never read near-ink against a tinted background.
+- **Do** reserve the single Menu Float shadow for popovers only.
+- **Do** keep selection and hover states whisper-subtle (gray at 10% / 5%).
+- **Do** protect the 650px measure and 1.5× line height for long-session comfort.
+- **Do** let the interface recede during timed writing — hiding the nav is a feature, not a bug.
+
+### Don't:
+- **Don't** introduce any accent or brand color — this is strictly monochrome (ink-only).
+- **Don't** build a cluttered Notion-style tool — no dense panels, nested database chrome, or feature-soup navigation.
+- **Don't** ship generic Notes.app blandness — every detail must feel considered, not default.
+- **Don't** go dark "developer-tool" — no terminal green/amber, no neon, no glassmorphism.
+- **Don't** add card shadows, gradient text, side-stripe colored borders, or oversized radii (≥16px) anywhere.
+- **Don't** gate content visibility behind a hover or reveal state — what matters must be visible by default.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,38 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Distraction-free writers and journalers who want to capture thoughts exactly when they happen, without ceremony. They journal by free writing, record short video thoughts, and revisit entries later. Their context: often late at night or in a quiet moment, in flow, wanting the tool to get out of the way so the thinking stays theirs.
+
+## Product Purpose
+
+Freewrite is a distraction-free macOS writing environment built around stream-of-consciousness writing and video journaling. It removes the friction between thought and capture: no save button, no "New Document" dialog, no formatting decisions — you open it and type or record. Everything is auto-saved locally as plain files the user owns. Success looks like a user entering flow immediately and capturing more, more honestly, than they would in a heavier tool.
+
+## Brand Personality
+
+Fast, light, frictionless. Calm, minimal, human. The voice is a friend, not a tool or a therapist — warm, direct, slightly casual, never clinical, never corporate. The interface is quiet and nearly invisible so the writing is the only thing on screen.
+
+## Anti-references
+
+- Not a cluttered Notion-style tool — no dense panels, nested databases, or feature-soup chrome.
+- Not generic Notes.app — no stock "card list of memos" blandness; every detail should feel considered, not default.
+- Not a slick dark developer tool — it should feel warm and human, not terminal-native.
+
+## Design Principles
+
+- **Get out of the way.** The interface's job is to disappear. Most UI hides during timed sessions; the text (or video) is the whole point.
+- **Practice what you preach.** The app itself should feel as frictionless as the writing it enables — no dialogs, no setup, auto-everything.
+- **Start instantly.** Open the app and you're already writing today's entry; no blank "new document" gate.
+- **Human over clinical.** Tone and detail should read as a friend's helping hand — comfort, validation, warmth — not a sterile product.
+- **Local-first ownership.** Every thought lives in a plain file the user can open; transparency and control over cleverness.
+
+## Accessibility & Inclusion
+
+- Full dark and light modes, user-switchable and persisted.
+- Wide font-size range (16–26px) and multiple font options including system and serif, with generous 1.5× line height for long-session comfort.
+- Distraction-reduction is opt-in and reversible: backspace lock, focus timer, auto-hiding nav.
+- Reduced-distraction flows must never hide or block core content; reveal states stay visible by default.

--- a/freewrite/ContentView.swift
+++ b/freewrite/ContentView.swift
@@ -57,7 +57,7 @@ struct ContentView: View {
     @State private var text: String = ""  // Remove initial welcome text since we'll handle it in createNewEntry
     
     private let selectedFont: String = "Lato-Regular"
-    private let fontSize: CGFloat = 18
+    private let fontSize: CGFloat = 14
     @State private var bottomNavOpacity: Double = 1.0
     @State private var isHoveringBottomNav = false
     @State private var selectedEntryIndex: Int = 0
@@ -639,31 +639,33 @@ struct ContentView: View {
                 } else {
                     // Show text editor for text entries
                     TextEditor(text: $text)
-                    .background(Color(colorScheme == .light ? .white : .black))
-                    .font(.custom(selectedFont, size: fontSize))
-                    .foregroundColor(colorScheme == .light ? Color(red: 0.20, green: 0.20, blue: 0.20) : Color(red: 0.9, green: 0.9, blue: 0.9))
-                    .scrollContentBackground(.hidden)
-                    .scrollIndicators(.never)
-                    .lineSpacing(lineHeight)
-                    .frame(maxWidth: 650)
-                    .padding(.top, 40)
-                    .id("\(selectedFont)-\(fontSize)-\(colorScheme)")
-                    .padding(.bottom, bottomNavOpacity > 0 ? navHeight : 0)
-                    .colorScheme(colorScheme)
-                    .onAppear {
-                        placeholderText = placeholderOptions.randomElement() ?? "Begin writing"
-                    }
-                    .overlay(
-                        ZStack(alignment: .topLeading) {
+                        .background(Color(colorScheme == .light ? .white : .black))
+                        .font(.custom(selectedFont, size: fontSize))
+                        .foregroundColor(colorScheme == .light ? Color(red: 0.20, green: 0.20, blue: 0.20) : Color(red: 0.9, green: 0.9, blue: 0.9))
+                        .scrollContentBackground(.hidden)
+                        .scrollIndicators(.never)
+                        .lineSpacing(lineHeight)
+                        // Placeholder shares the editor's coordinate space so it sits on the first line.
+                        .overlay(alignment: .topLeading) {
                             if text.isEmpty {
                                 Text(placeholderText)
                                     .font(.custom(selectedFont, size: fontSize))
                                     .foregroundColor(colorScheme == .light ? .gray.opacity(0.5) : .gray.opacity(0.6))
+                                    // Match NSTextView's default textContainerInset (5, 0) — no extra top inset.
+                                    .padding(.leading, 5)
                                     .allowsHitTesting(false)
-                                    .offset(x: 5, y: 40)
                             }
-                        }, alignment: .topLeading
-                    )
+                        }
+                        .frame(maxWidth: 650, maxHeight: .infinity, alignment: .topLeading)
+                        .padding(.top, 40)
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, bottomNavOpacity > 0 ? navHeight : 0)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        .id("\(selectedFont)-\(fontSize)-\(colorScheme)")
+                        .colorScheme(colorScheme)
+                        .onAppear {
+                            placeholderText = placeholderOptions.randomElement() ?? "Begin writing"
+                        }
                 }
 
                 // Bottom nav
@@ -970,7 +972,9 @@ struct ContentView: View {
                 .background(Color(colorScheme == .light ? .white : NSColor.black))
             }
         }
-        .frame(minWidth: 1100, minHeight: 600)
+        // Keep the editor usable at compact sizes: sidebar is fixed 200pt wide,
+        // and top padding (40) + bottom nav (68) need leftover vertical room to write.
+        .frame(minWidth: showingSidebar ? 480 : 280, minHeight: 200)
         .animation(.easeInOut(duration: 0.2), value: showingSidebar)
         .preferredColorScheme(colorScheme)
         .background(WindowTitleAccessor(title: currentEntryTitle, isDark: colorScheme == .dark))
@@ -1157,9 +1161,9 @@ struct ContentView: View {
             return "Entry \(date)"
         }
         
-        // Split content into words, ignoring newlines and removing punctuation
-        let words = trimmedContent
-            .replacingOccurrences(of: "\n", with: " ")
+        // Split only the first line into words and remove punctuation
+        let firstLine = trimmedContent.components(separatedBy: .newlines).first ?? ""
+        let words = firstLine
             .components(separatedBy: .whitespaces)
             .filter { !$0.isEmpty }
             .map { word in

--- a/freewrite/ContentView.swift
+++ b/freewrite/ContentView.swift
@@ -593,6 +593,26 @@ struct ContentView: View {
         return (fontSize * 1.5) - defaultLineHeight
     }
 
+    private var currentEntryTitle: String {
+        guard let selectedEntryId,
+              let entry = entries.first(where: { $0.id == selectedEntryId }) else {
+            return "Untitled"
+        }
+
+        if entry.entryType == .video {
+            return entry.previewText.isEmpty ? "Video Entry" : entry.previewText
+        }
+
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedText.isEmpty {
+            return "Untitled"
+        }
+
+        let firstLine = trimmedText.components(separatedBy: .newlines).first ?? trimmedText
+        let cleaned = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? "Untitled" : cleaned
+    }
+
     
     var body: some View {
         let buttonBackground = colorScheme == .light ? Color.white : Color.black
@@ -645,8 +665,8 @@ struct ContentView: View {
                         }, alignment: .topLeading
                     )
                 }
-                    
-                
+
+                // Bottom nav
                 VStack {
                     Spacer()
                     HStack {
@@ -756,17 +776,17 @@ struct ContentView: View {
                     .padding()
                     .background(Color(colorScheme == .light ? .white : .black))
                     .opacity(bottomNavOpacity)
-                    .onHover { hovering in
-                        isHoveringBottomNav = hovering
-                        if hovering {
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                bottomNavOpacity = 1.0
+                        .onHover { hovering in
+                            isHoveringBottomNav = hovering
+                            if hovering {
+                                withAnimation(.easeOut(duration: 0.2)) {
+                                    bottomNavOpacity = 1.0
+                                }
                             }
                         }
-                    }
                 }
             }
-            
+
             // Right sidebar
             if showingSidebar {
                 Divider()
@@ -953,6 +973,7 @@ struct ContentView: View {
         .frame(minWidth: 1100, minHeight: 600)
         .animation(.easeInOut(duration: 0.2), value: showingSidebar)
         .preferredColorScheme(colorScheme)
+        .background(WindowTitleAccessor(title: currentEntryTitle, isDark: colorScheme == .dark))
         .onAppear {
             showingSidebar = false  // Hide sidebar by default
             loadExistingEntries()

--- a/freewrite/ContentView.swift
+++ b/freewrite/ContentView.swift
@@ -44,29 +44,6 @@ struct HumanEntry: Identifiable {
             videoFilename: nil
         )
     }
-
-    static func createVideoEntry() -> HumanEntry {
-        let id = UUID()
-        let now = Date()
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
-        let dateString = dateFormatter.string(from: now)
-
-        // For display
-        dateFormatter.dateFormat = "MMM d"
-        let displayDate = dateFormatter.string(from: now)
-
-        let videoFilename = "[\(id)]-[\(dateString)].mov"
-
-        return HumanEntry(
-            id: id,
-            date: displayDate,
-            filename: "[\(id)]-[\(dateString)].md",
-            previewText: "Video Entry",
-            entryType: .video,
-            videoFilename: videoFilename
-        )
-    }
 }
 
 struct HeartEmoji: Identifiable {
@@ -76,40 +53,17 @@ struct HeartEmoji: Identifiable {
 }
 
 struct ContentView: View {
-    private struct VideoPermissionPopoverItem: Identifiable {
-        let id = UUID()
-        let message: String
-        let buttonLabel: String
-        let settingsPane: String
-    }
-
     @State private var entries: [HumanEntry] = []
     @State private var text: String = ""  // Remove initial welcome text since we'll handle it in createNewEntry
     
-    @State private var isFullscreen = false
-    @State private var selectedFont: String = "Lato-Regular"
-    @State private var currentRandomFont: String = ""
-    @State private var timeRemaining: Int = 900  // Changed to 900 seconds (15 minutes)
-    @State private var timerIsRunning = false
-    @State private var isHoveringTimer = false
-    @State private var isHoveringFullscreen = false
-    @State private var hoveredFont: String? = nil
-    @State private var isHoveringSize = false
-    @State private var fontSize: CGFloat = 18
-    @State private var blinkCount = 0
-    @State private var isBlinking = false
-    @State private var opacity: Double = 1.0
-    @State private var shouldShowGray = true // New state to control color
-    @State private var lastClickTime: Date? = nil
+    private let selectedFont: String = "Lato-Regular"
+    private let fontSize: CGFloat = 18
     @State private var bottomNavOpacity: Double = 1.0
     @State private var isHoveringBottomNav = false
     @State private var selectedEntryIndex: Int = 0
     @State private var scrollOffset: CGFloat = 0
     @State private var selectedEntryId: UUID? = nil
     @State private var hoveredEntryId: UUID? = nil
-    @State private var isHoveringChat = false  // Add this state variable
-    @State private var showingChatMenu = false
-    @State private var chatMenuAnchor: CGPoint = .zero
     @State private var showingSidebar = false  // Add this state variable
     @State private var hoveredTrashId: UUID? = nil
     @State private var hoveredExportId: UUID? = nil
@@ -123,26 +77,11 @@ struct ContentView: View {
     @State private var isHoveringCopyTranscript = false
     @State private var colorScheme: ColorScheme = .light // Add state for color scheme
     @State private var isHoveringThemeToggle = false // Add state for theme toggle hover
-    @State private var didCopyPrompt: Bool = false // Add state for copy prompt feedback
     @State private var didCopyTranscript: Bool = false
     @State private var selectedVideoHasTranscript = false
-    @State private var backspaceDisabled = false // Add state for backspace toggle
-    @State private var isHoveringBackspaceToggle = false // Add state for backspace toggle hover
-    @State private var showingVideoRecording = false // Add state for video recording view
-    @State private var isHoveringVideoButton = false // Add state for video button hover
     @State private var currentVideoURL: URL? = nil // Add state for current video being viewed
-    @State private var isPreparingVideoRecording = false
-    @State private var preparedCameraManager: CameraManager? = nil
-    @State private var videoRecordingPreparationID: UUID? = nil
-    @State private var showingVideoPermissionPopover = false
-    @State private var videoPermissionPopoverItems: [VideoPermissionPopoverItem] = []
-    @State private var videoPermissionPopoverFallbackMessage: String? = nil
-    let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     let entryHeight: CGFloat = 40
     
-    let availableFonts = NSFontManager.shared.availableFontFamilies
-    let standardFonts = ["Lato-Regular", "Arial", ".AppleSystemUIFont", "Times New Roman"]
-    let fontSizes: [CGFloat] = [16, 18, 20, 22, 24, 26]
     let placeholderOptions = [
         "Begin writing",
         "Pick a thought and go",
@@ -197,33 +136,6 @@ struct ContentView: View {
         cache.countLimit = 512
         return cache
     }()
-    
-    // Add shared prompt constant
-    private let aiChatPrompt = """
-    below is my journal entry. wyt? talk through it with me like a friend. don't therpaize me and give me a whole breakdown, don't repeat my thoughts with headings. really take all of this, and tell me back stuff truly as if you're an old homie.
-    
-    Keep it casual, dont say yo, help me make new connections i don't see, comfort, validate, challenge, all of it. dont be afraid to say a lot. format with markdown headings if needed.
-
-    do not just go through every single thing i say, and say it back to me. you need to proccess everythikng is say, make connections i don't see it, and deliver it all back to me as a story that makes me feel what you think i wanna feel. thats what the best therapists do.
-
-    ideally, you're style/tone should sound like the user themselves. it's as if the user is hearing their own tone but it should still feel different, because you have different things to say and don't just repeat back they say.
-
-    else, start by saying, "hey, thanks for showing me this. my thoughts:"
-        
-    my entry:
-    """
-    
-    private let claudePrompt = """
-    Take a look at my journal entry below. I'd like you to analyze it and respond with deep insight that feels personal, not clinical.
-    Imagine you're not just a friend, but a mentor who truly gets both my tech background and my psychological patterns. I want you to uncover the deeper meaning and emotional undercurrents behind my scattered thoughts.
-    Keep it casual, dont say yo, help me make new connections i don't see, comfort, validate, challenge, all of it. dont be afraid to say a lot. format with markdown headings if needed.
-    Use vivid metaphors and powerful imagery to help me see what I'm really building. Organize your thoughts with meaningful headings that create a narrative journey through my ideas.
-    Don't just validate my thoughts - reframe them in a way that shows me what I'm really seeking beneath the surface. Go beyond the product concepts to the emotional core of what I'm trying to solve.
-    Be willing to be profound and philosophical without sounding like you're giving therapy. I want someone who can see the patterns I can't see myself and articulate them in a way that feels like an epiphany.
-    Start with 'hey, thanks for showing me this. my thoughts:' and then use markdown headings to structure your response.
-
-    Here's my journal entry:
-    """
     
     // Initialize with saved theme preference if available
     init() {
@@ -675,190 +587,10 @@ struct ContentView: View {
         }
     }
     
-    var randomButtonTitle: String {
-        return currentRandomFont.isEmpty ? "Random" : "Random [\(currentRandomFont)]"
-    }
-
-    private func startVideoRecordingPreflight() {
-        guard !isPreparingVideoRecording, !showingVideoRecording else {
-            return
-        }
-
-        showingVideoPermissionPopover = false
-        videoPermissionPopoverItems = []
-        videoPermissionPopoverFallbackMessage = nil
-
-        let preparationID = UUID()
-        let manager = CameraManager()
-
-        videoRecordingPreparationID = preparationID
-        preparedCameraManager = manager
-
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
-            isPreparingVideoRecording = true
-        }
-
-        manager.onReadyToRecord = { [weak manager] in
-            guard let manager else { return }
-            DispatchQueue.main.async {
-                finishVideoRecordingPreflight(
-                    preparationID: preparationID,
-                    manager: manager,
-                    presentationDelay: 0.5
-                )
-            }
-        }
-
-        manager.onCannotRecord = { [weak manager] in
-            guard let manager else { return }
-            DispatchQueue.main.async {
-                guard self.videoRecordingPreparationID == preparationID else {
-                    return
-                }
-                let payload = self.videoPermissionPopoverPayload(
-                    cameraGranted: manager.permissionGranted,
-                    microphoneGranted: manager.microphonePermissionGranted,
-                    speechGranted: manager.speechPermissionGranted
-                )
-                self.videoPermissionPopoverItems = payload.items
-                self.videoPermissionPopoverFallbackMessage = payload.fallbackMessage
-                self.showingVideoPermissionPopover = true
-                self.clearVideoRecordingPreparationState()
-            }
-        }
-
-        manager.checkPermissions()
-    }
-
-    private func finishVideoRecordingPreflight(
-        preparationID: UUID,
-        manager: CameraManager,
-        presentationDelay: TimeInterval = 0
-    ) {
-        let presentRecorder = {
-            guard videoRecordingPreparationID == preparationID else {
-                return
-            }
-
-            videoRecordingPreparationID = nil
-            manager.onReadyToRecord = nil
-            manager.onCannotRecord = nil
-            preparedCameraManager = manager
-
-            var transaction = Transaction()
-            transaction.disablesAnimations = true
-            withTransaction(transaction) {
-                isPreparingVideoRecording = false
-                showingVideoRecording = true
-            }
-        }
-
-        if presentationDelay > 0 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + presentationDelay) {
-                presentRecorder()
-            }
-        } else {
-            presentRecorder()
-        }
-    }
-
-    private func clearVideoRecordingPreparationState() {
-        preparedCameraManager?.onReadyToRecord = nil
-        preparedCameraManager?.onCannotRecord = nil
-        videoRecordingPreparationID = nil
-        isPreparingVideoRecording = false
-        preparedCameraManager = nil
-    }
-
-    private func videoPermissionPopoverPayload(
-        cameraGranted: Bool,
-        microphoneGranted: Bool,
-        speechGranted: Bool
-    ) -> (items: [VideoPermissionPopoverItem], fallbackMessage: String?) {
-        var items: [VideoPermissionPopoverItem] = []
-        if !cameraGranted {
-            items.append(
-                VideoPermissionPopoverItem(
-                    message: "Hey, we need camera permission.",
-                    buttonLabel: "Open Camera Settings",
-                    settingsPane: "Privacy_Camera"
-                )
-            )
-        }
-        if !microphoneGranted {
-            items.append(
-                VideoPermissionPopoverItem(
-                    message: "Hey, we need microphone permission.",
-                    buttonLabel: "Open Microphone Settings",
-                    settingsPane: "Privacy_Microphone"
-                )
-            )
-        }
-        if !speechGranted {
-            items.append(
-                VideoPermissionPopoverItem(
-                    message: "Hey, we need speech recognition permission.",
-                    buttonLabel: "Open Speech Settings",
-                    settingsPane: "Privacy_SpeechRecognition"
-                )
-            )
-        }
-
-        if items.isEmpty {
-            return (
-                items: [],
-                fallbackMessage: "Could not prepare camera right now. Please try again."
-            )
-        }
-
-        return (
-            items: items,
-            fallbackMessage: nil
-        )
-    }
-
-    private func openVideoPermissionSettings(_ settingsPane: String) {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(settingsPane)") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
-    var timerButtonTitle: String {
-        if !timerIsRunning && timeRemaining == 900 {
-            return "15:00"
-        }
-        let minutes = timeRemaining / 60
-        let seconds = timeRemaining % 60
-        return String(format: "%d:%02d", minutes, seconds)
-    }
-    
-    var timerColor: Color {
-        if timerIsRunning {
-            return isHoveringTimer ? (colorScheme == .light ? .black : .white) : .gray.opacity(0.8)
-        } else {
-            return isHoveringTimer ? (colorScheme == .light ? .black : .white) : (colorScheme == .light ? .gray : .gray.opacity(0.8))
-        }
-    }
-    
     var lineHeight: CGFloat {
         let font = NSFont(name: selectedFont, size: fontSize) ?? .systemFont(ofSize: fontSize)
         let defaultLineHeight = getLineHeight(font: font)
         return (fontSize * 1.5) - defaultLineHeight
-    }
-    
-    var fontSizeButtonTitle: String {
-        return "\(Int(fontSize))px"
-    }
-    
-    // Add a color utility computed property
-    var popoverBackgroundColor: Color {
-        return colorScheme == .light ? Color(NSColor.controlBackgroundColor) : Color(NSColor.darkGray)
-    }
-    
-    var popoverTextColor: Color {
-        return colorScheme == .light ? Color.primary : Color.white
     }
 
     
@@ -879,7 +611,7 @@ struct ContentView: View {
                 if let videoURL = currentVideoURL {
                     VideoPlayerView(
                         videoURL: videoURL,
-                        isPlaybackSuspended: isPreparingVideoRecording || showingVideoRecording
+                        isPlaybackSuspended: false
                     )
                         .id(videoURL.path)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -900,17 +632,6 @@ struct ContentView: View {
                     .colorScheme(colorScheme)
                     .onAppear {
                         placeholderText = placeholderOptions.randomElement() ?? "Begin writing"
-                        // Removed findSubview code which was causing errors
-
-                        // Add keyboard monitor for backspace/delete keys
-                        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-                            // Check if backspace is disabled and the key is delete/backspace
-                            if backspaceDisabled && (event.keyCode == 51 || event.keyCode == 117) {
-                                // Block the backspace/delete key
-                                return nil
-                            }
-                            return event
-                        }
                     }
                     .overlay(
                         ZStack(alignment: .topLeading) {
@@ -956,466 +677,12 @@ struct ContentView: View {
                             .onHover { hovering in
                                 isHoveringBottomNav = hovering
                             }
-                        } else {
-                            // Font buttons (left)
-                            HStack(spacing: 8) {
-                                Button(fontSizeButtonTitle) {
-                                    if let currentIndex = fontSizes.firstIndex(of: fontSize) {
-                                        let nextIndex = (currentIndex + 1) % fontSizes.count
-                                        fontSize = fontSizes[nextIndex]
-                                    }
-                                }
-                                .buttonStyle(.plain)
-                                .foregroundColor(isHoveringSize ? textHoverColor : textColor)
-                                .onHover { hovering in
-                                    isHoveringSize = hovering
-                                    isHoveringBottomNav = hovering
-                                    if hovering {
-                                        NSCursor.pointingHand.push()
-                                    } else {
-                                        NSCursor.pop()
-                                    }
-                                }
-                                
-                                Text("•")
-                                    .foregroundColor(.gray)
-                                
-                                Button("Lato") {
-                                    selectedFont = "Lato-Regular"
-                                    currentRandomFont = ""
-                                }
-                                .buttonStyle(.plain)
-                                .foregroundColor(hoveredFont == "Lato" ? textHoverColor : textColor)
-                                .onHover { hovering in
-                                    hoveredFont = hovering ? "Lato" : nil
-                                    isHoveringBottomNav = hovering
-                                    if hovering {
-                                        NSCursor.pointingHand.push()
-                                    } else {
-                                        NSCursor.pop()
-                                    }
-                                }
-                                
-                                Text("•")
-                                    .foregroundColor(.gray)
-                                
-                                Button("Arial") {
-                                    selectedFont = "Arial"
-                                    currentRandomFont = ""
-                                }
-                                .buttonStyle(.plain)
-                                .foregroundColor(hoveredFont == "Arial" ? textHoverColor : textColor)
-                                .onHover { hovering in
-                                    hoveredFont = hovering ? "Arial" : nil
-                                    isHoveringBottomNav = hovering
-                                    if hovering {
-                                        NSCursor.pointingHand.push()
-                                    } else {
-                                        NSCursor.pop()
-                                    }
-                                }
-                                
-                                Text("•")
-                                    .foregroundColor(.gray)
-                                
-                                Button("System") {
-                                    selectedFont = ".AppleSystemUIFont"
-                                    currentRandomFont = ""
-                                }
-                                .buttonStyle(.plain)
-                                .foregroundColor(hoveredFont == "System" ? textHoverColor : textColor)
-                                .onHover { hovering in
-                                    hoveredFont = hovering ? "System" : nil
-                                    isHoveringBottomNav = hovering
-                                    if hovering {
-                                        NSCursor.pointingHand.push()
-                                    } else {
-                                        NSCursor.pop()
-                                    }
-                                }
-                                
-                                Text("•")
-                                    .foregroundColor(.gray)
-                                
-                                Button("Serif") {
-                                    selectedFont = "Times New Roman"
-                                    currentRandomFont = ""
-                                }
-                                .buttonStyle(.plain)
-                                .foregroundColor(hoveredFont == "Serif" ? textHoverColor : textColor)
-                                .onHover { hovering in
-                                    hoveredFont = hovering ? "Serif" : nil
-                                    isHoveringBottomNav = hovering
-                                    if hovering {
-                                        NSCursor.pointingHand.push()
-                                    } else {
-                                        NSCursor.pop()
-                                    }
-                                }
-                                
-                                Text("•")
-                                    .foregroundColor(.gray)
-                                
-                                Button(randomButtonTitle) {
-                                    if let randomFont = availableFonts.randomElement() {
-                                        selectedFont = randomFont
-                                        currentRandomFont = randomFont
-                                    }
-                                }
-                                .buttonStyle(.plain)
-                                .foregroundColor(hoveredFont == "Random" ? textHoverColor : textColor)
-                                .onHover { hovering in
-                                    hoveredFont = hovering ? "Random" : nil
-                                    isHoveringBottomNav = hovering
-                                    if hovering {
-                                        NSCursor.pointingHand.push()
-                                    } else {
-                                        NSCursor.pop()
-                                    }
-                                }
-                            }
-                            .padding(8)
-                            .cornerRadius(6)
-                            .onHover { hovering in
-                                isHoveringBottomNav = hovering
-                            }
                         }
                         
                         Spacer()
                         
                         // Utility buttons (moved to right)
                         HStack(spacing: 8) {
-                            Button(timerButtonTitle) {
-                                let now = Date()
-                                if let lastClick = lastClickTime,
-                                   now.timeIntervalSince(lastClick) < 0.3 {
-                                    timeRemaining = 900
-                                    timerIsRunning = false
-                                    lastClickTime = nil
-                                } else {
-                                    timerIsRunning.toggle()
-                                    lastClickTime = now
-                                }
-                            }
-                            .buttonStyle(.plain)
-                            .foregroundColor(timerColor)
-                            .onHover { hovering in
-                                isHoveringTimer = hovering
-                                isHoveringBottomNav = hovering
-                                if hovering {
-                                    NSCursor.pointingHand.push()
-                                } else {
-                                    NSCursor.pop()
-                                }
-                            }
-                            .onAppear {
-                                NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { event in
-                                    if isHoveringTimer {
-                                        let scrollBuffer = event.deltaY * 0.25
-                                        
-                                        if abs(scrollBuffer) >= 0.1 {
-                                            let currentMinutes = timeRemaining / 60
-                                            NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .now)
-                                            let direction = -scrollBuffer > 0 ? 5 : -5
-                                            let newMinutes = currentMinutes + direction
-                                            let roundedMinutes = (newMinutes / 5) * 5
-                                            let newTime = roundedMinutes * 60
-                                            timeRemaining = min(max(newTime, 0), 2700)
-                                        }
-                                    }
-                                    return event
-                                }
-                            }
-
-                            Text("•")
-                                .foregroundColor(.gray)
-
-                            // Video camera button
-                            Button(action: {
-                                guard !isPreparingVideoRecording else { return }
-                                startVideoRecordingPreflight()
-                            }) {
-                                Group {
-                                    if isPreparingVideoRecording {
-                                        ProgressView()
-                                            .controlSize(.small)
-                                            .tint(isHoveringVideoButton ? textHoverColor : textColor)
-                                    } else {
-                                        Image(systemName: "video.fill")
-                                            .foregroundColor(isHoveringVideoButton ? textHoverColor : textColor)
-                                    }
-                                }
-                                .frame(width: 14, height: 14)
-                            }
-                            .buttonStyle(.plain)
-                            .onHover { hovering in
-                                isHoveringVideoButton = hovering
-                                isHoveringBottomNav = hovering
-                                if hovering {
-                                    NSCursor.pointingHand.push()
-                                } else {
-                                    NSCursor.pop()
-                                }
-                            }
-                            .popover(
-                                isPresented: $showingVideoPermissionPopover,
-                                attachmentAnchor: .point(UnitPoint(x: 0.5, y: 0.0)),
-                                arrowEdge: .top
-                            ) {
-                                VStack(spacing: 0) {
-                                    if let fallbackMessage = videoPermissionPopoverFallbackMessage {
-                                        Text(fallbackMessage)
-                                            .font(.system(size: 14))
-                                            .foregroundColor(popoverTextColor)
-                                            .lineLimit(nil)
-                                            .multilineTextAlignment(.leading)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .padding(.horizontal, 12)
-                                            .padding(.vertical, 8)
-                                }
-
-                                    ForEach(videoPermissionPopoverItems) { item in
-                                        if item.id != videoPermissionPopoverItems.first?.id || videoPermissionPopoverFallbackMessage != nil {
-                                            Divider()
-                                        }
-
-                                        Button(action: {
-                                            showingVideoPermissionPopover = false
-                                            openVideoPermissionSettings(item.settingsPane)
-                                        }) {
-                                            VStack(alignment: .leading, spacing: 3) {
-                                                Text(item.message)
-                                                    .font(.system(size: 14))
-                                                    .lineLimit(nil)
-                                                    .multilineTextAlignment(.leading)
-                                                    .fixedSize(horizontal: false, vertical: true)
-
-                                                Text(item.buttonLabel)
-                                                    .font(.system(size: 12))
-                                                    .opacity(0.85)
-                                            }
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .padding(.horizontal, 12)
-                                            .padding(.vertical, 8)
-                                        }
-                                        .buttonStyle(.plain)
-                                        .foregroundColor(popoverTextColor)
-                                        .onHover { hovering in
-                                            if hovering {
-                                                NSCursor.pointingHand.push()
-                                            } else {
-                                                NSCursor.pop()
-                                            }
-                                        }
-                                    }
-                                }
-                                .frame(minWidth: 300, idealWidth: 320, maxWidth: 360)
-                                .background(colorScheme == .light ? Color.white : Color.black)
-                            }
-
-                            Text("•")
-                                .foregroundColor(.gray)
-
-                            Button("Chat") {
-                                showingChatMenu = true
-                                // Ensure didCopyPrompt is reset when opening the menu
-                                didCopyPrompt = false
-                            }
-                            .buttonStyle(.plain)
-                            .foregroundColor(isHoveringChat ? textHoverColor : textColor)
-                            .onHover { hovering in
-                                isHoveringChat = hovering
-                                isHoveringBottomNav = hovering
-                                if hovering {
-                                    NSCursor.pointingHand.push()
-                                } else {
-                                    NSCursor.pop()
-                                }
-                            }
-                            .popover(isPresented: $showingChatMenu, attachmentAnchor: .point(UnitPoint(x: 0.5, y: 0)), arrowEdge: .top) {
-                                VStack(spacing: 0) { // Wrap everything in a VStack for consistent styling and onChange
-                                    let isVideoEntry = currentVideoURL != nil
-                                    let chatSourceText = currentChatSourceText()
-                                    
-                                    // Calculate potential URL lengths
-                                    let gptFullText = aiChatPrompt + "\n\n" + chatSourceText
-                                    let claudeFullText = claudePrompt + "\n\n" + chatSourceText
-                                    let encodedGptText = gptFullText.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-                                    let encodedClaudeText = claudeFullText.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-                                    
-                                    let gptUrlLength = "https://chat.openai.com/?m=".count + encodedGptText.count
-                                    let claudeUrlLength = "https://claude.ai/new?q=".count + encodedClaudeText.count
-                                    let isUrlTooLong = gptUrlLength > 6000 || claudeUrlLength > 6000
-                                    
-                                    if isUrlTooLong {
-                                        // View for long text (URL too long)
-                                        Text("Hey, your entry is quite long. You'll need to manually copy the prompt by clicking 'Copy Prompt' below and then paste it into AI of your choice (ex. ChatGPT). The prompt includes your entry as well. So just copy paste and go! See what the AI says.")
-                                            .font(.system(size: 14))
-                                            .foregroundColor(popoverTextColor)
-                                            .lineLimit(nil)
-                                            .multilineTextAlignment(.leading)
-                                            .frame(width: 200, alignment: .leading)
-                                            .padding(.horizontal, 12)
-                                            .padding(.vertical, 8)
-                                        
-                                        Divider()
-                                        
-                                        Button(action: {
-                                            copyPromptToClipboard()
-                                            didCopyPrompt = true
-                                        }) {
-                                            Text(didCopyPrompt ? "Copied!" : "Copy Prompt")
-                                                .frame(maxWidth: .infinity, alignment: .leading)
-                                                .padding(.horizontal, 12)
-                                                .padding(.vertical, 8)
-                                        }
-                                        .buttonStyle(.plain)
-                                        .foregroundColor(popoverTextColor)
-                                        .onHover { hovering in
-                                            if hovering {
-                                                NSCursor.pointingHand.push()
-                                            } else {
-                                                NSCursor.pop()
-                                            }
-                                        }
-                                        
-                                    } else if !isVideoEntry && text.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("hi. my name is farza.") {
-                                        Text("Yo. Sorry, you can't chat with the guide lol. Please write your own entry.")
-                                            .font(.system(size: 14))
-                                            .foregroundColor(popoverTextColor)
-                                            .frame(width: 250)
-                                            .padding(.horizontal, 12)
-                                            .padding(.vertical, 8)
-                                    } else if !isVideoEntry && text.count < 350 {
-                                        Text("Please free write for at minimum 5 minutes first. Then click this. Trust.")
-                                            .font(.system(size: 14))
-                                            .foregroundColor(popoverTextColor)
-                                            .frame(width: 250)
-                                            .padding(.horizontal, 12)
-                                            .padding(.vertical, 8)
-                                    } else {
-                                        // View for normal text length
-                                        Button(action: {
-                                            showingChatMenu = false
-                                            openChatGPT()
-                                        }) {
-                                            Text("ChatGPT")
-                                                .frame(maxWidth: .infinity, alignment: .leading)
-                                                .padding(.horizontal, 12)
-                                                .padding(.vertical, 8)
-                                        }
-                                        .buttonStyle(.plain)
-                                        .foregroundColor(popoverTextColor)
-                                        .onHover { hovering in
-                                            if hovering {
-                                                NSCursor.pointingHand.push()
-                                            } else {
-                                                NSCursor.pop()
-                                            }
-                                        }
-                                        
-                                        Divider()
-                                        
-                                        Button(action: {
-                                            showingChatMenu = false
-                                            openClaude()
-                                        }) {
-                                            Text("Claude")
-                                                .frame(maxWidth: .infinity, alignment: .leading)
-                                                .padding(.horizontal, 12)
-                                                .padding(.vertical, 8)
-                                        }
-                                        .buttonStyle(.plain)
-                                        .foregroundColor(popoverTextColor)
-                                        .onHover { hovering in
-                                            if hovering {
-                                                NSCursor.pointingHand.push()
-                                            } else {
-                                                NSCursor.pop()
-                                            }
-                                        }
-                                        
-                                        Divider()
-                                        
-                                        Button(action: {
-                                            // Don't dismiss menu, just copy and update state
-                                            copyPromptToClipboard()
-                                            didCopyPrompt = true
-                                        }) {
-                                            Text(didCopyPrompt ? "Copied!" : "Copy Prompt")
-                                                .frame(maxWidth: .infinity, alignment: .leading)
-                                                .padding(.horizontal, 12)
-                                                .padding(.vertical, 8)
-                                        }
-                                        .buttonStyle(.plain)
-                                        .foregroundColor(popoverTextColor)
-                                        .onHover { hovering in
-                                            if hovering {
-                                                NSCursor.pointingHand.push()
-                                            } else {
-                                                NSCursor.pop()
-                                            }
-                                        }
-                                    }
-                                }
-                                .frame(minWidth: 120, maxWidth: 250) // Allow width to adjust
-                                .background(popoverBackgroundColor)
-                                .cornerRadius(8)
-                                .shadow(color: Color.black.opacity(0.1), radius: 4, y: 2)
-                                // Reset copied state when popover dismisses
-                                .onChange(of: showingChatMenu) { newValue in
-                                    if !newValue {
-                                        didCopyPrompt = false
-                                    }
-                                }
-                            }
-                            
-                            Text("•")
-                                .foregroundColor(.gray)
-
-                            if !isViewingVideoEntry {
-                                // Backspace toggle button
-                                Button(action: {
-                                    backspaceDisabled.toggle()
-                                }) {
-                                    Text(backspaceDisabled ? "Backspace is Off" : "Backspace is On")
-                                        .foregroundColor(isHoveringBackspaceToggle ? textHoverColor : textColor)
-                                }
-                                .buttonStyle(.plain)
-                                .onHover { hovering in
-                                    isHoveringBackspaceToggle = hovering
-                                    isHoveringBottomNav = hovering
-                                    if hovering {
-                                        NSCursor.pointingHand.push()
-                                    } else {
-                                        NSCursor.pop()
-                                    }
-                                }
-
-                                Text("•")
-                                    .foregroundColor(.gray)
-                            }
-
-                            Button(isFullscreen ? "Minimize" : "Fullscreen") {
-                                if let window = NSApplication.shared.windows.first {
-                                    window.toggleFullScreen(nil)
-                                }
-                            }
-                            .buttonStyle(.plain)
-                            .foregroundColor(isHoveringFullscreen ? textHoverColor : textColor)
-                            .onHover { hovering in
-                                isHoveringFullscreen = hovering
-                                isHoveringBottomNav = hovering
-                                if hovering {
-                                    NSCursor.pointingHand.push()
-                                } else {
-                                    NSCursor.pop()
-                                }
-                            }
-                            
-                            Text("•")
-                                .foregroundColor(.gray)
-                            
                             Button(action: {
                                 createNewEntry()
                             }) {
@@ -1494,10 +761,6 @@ struct ContentView: View {
                         if hovering {
                             withAnimation(.easeOut(duration: 0.2)) {
                                 bottomNavOpacity = 1.0
-                            }
-                        } else if timerIsRunning {
-                            withAnimation(.easeIn(duration: 1.0)) {
-                                bottomNavOpacity = 0.0
                             }
                         }
                     }
@@ -1687,34 +950,12 @@ struct ContentView: View {
                 .background(Color(colorScheme == .light ? .white : NSColor.black))
             }
         }
-        .overlay {
-            if showingVideoRecording {
-                VideoRecordingView(
-                    isPresented: $showingVideoRecording,
-                    cameraManager: preparedCameraManager
-                ) { videoURL, transcript in
-                    // Save the video and create entry
-                    saveVideoEntry(from: videoURL, transcript: transcript)
-                    var transaction = Transaction()
-                    transaction.disablesAnimations = true
-                    withTransaction(transaction) {
-                        showingVideoRecording = false
-                    }
-                }
-                .zIndex(10)
-            }
-        }
         .frame(minWidth: 1100, minHeight: 600)
         .animation(.easeInOut(duration: 0.2), value: showingSidebar)
         .preferredColorScheme(colorScheme)
         .onAppear {
             showingSidebar = false  // Hide sidebar by default
             loadExistingEntries()
-        }
-        .onChange(of: showingVideoRecording) { _, isShowing in
-            if !isShowing {
-                clearVideoRecordingPreparationState()
-            }
         }
         .onChange(of: text) { _ in
             // Save current entry when text changes
@@ -1723,24 +964,6 @@ struct ContentView: View {
                currentEntry.entryType == .text {
                 saveEntry(entry: currentEntry)
             }
-        }
-        .onReceive(timer) { _ in
-            if timerIsRunning && timeRemaining > 0 {
-                timeRemaining -= 1
-            } else if timeRemaining == 0 {
-                timerIsRunning = false
-                if !isHoveringBottomNav {
-                    withAnimation(.easeOut(duration: 1.0)) {
-                        bottomNavOpacity = 1.0
-                    }
-                }
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willEnterFullScreenNotification)) { _ in
-            isFullscreen = true
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willExitFullScreenNotification)) { _ in
-            isFullscreen = false
         }
     }
     
@@ -1867,153 +1090,6 @@ struct ContentView: View {
         }
     }
     
-    private func openChatGPT() {
-        let fullText = aiChatPrompt + "\n\n" + currentChatSourceText()
-        
-        if let encodedText = fullText.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-           let url = URL(string: "https://chat.openai.com/?prompt=" + encodedText) {
-            NSWorkspace.shared.open(url)
-        }
-    }
-    
-    private func openClaude() {
-        let fullText = claudePrompt + "\n\n" + currentChatSourceText()
-        
-        if let encodedText = fullText.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-           let url = URL(string: "https://claude.ai/new?q=" + encodedText) {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
-    private func copyPromptToClipboard() {
-        let fullText = aiChatPrompt + "\n\n" + currentChatSourceText()
-
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(fullText, forType: .string)
-        print("Prompt copied to clipboard")
-    }
-
-    private func currentChatSourceText() -> String {
-        if currentVideoURL != nil,
-           let selectedEntryId,
-           let selectedEntry = entries.first(where: { $0.id == selectedEntryId }),
-           let videoFilename = resolvedVideoFilename(for: selectedEntry),
-           let transcript = loadTranscriptText(for: videoFilename) {
-            return transcript.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        return text.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func saveVideoEntry(from tempURL: URL, transcript: String?) {
-        let replacementEntry = selectedEntryId
-            .flatMap { id in entries.first(where: { $0.id == id }) }
-            .flatMap { entry -> HumanEntry? in
-                guard entry.entryType == .text else { return nil }
-                guard text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
-                return entry
-            }
-
-        let videoEntry: HumanEntry
-        if let replacementEntry {
-            let videoFilename = replacementEntry.filename.replacingOccurrences(of: ".md", with: ".mov")
-            videoEntry = HumanEntry(
-                id: replacementEntry.id,
-                date: replacementEntry.date,
-                filename: replacementEntry.filename,
-                previewText: previewTextFromTranscript(transcript),
-                entryType: .video,
-                videoFilename: videoFilename
-            )
-        } else {
-            let newEntry = HumanEntry.createVideoEntry()
-            videoEntry = HumanEntry(
-                id: newEntry.id,
-                date: newEntry.date,
-                filename: newEntry.filename,
-                previewText: previewTextFromTranscript(transcript),
-                entryType: .video,
-                videoFilename: newEntry.videoFilename
-            )
-        }
-
-        // Get the documents directory
-        let documentsDirectory = getDocumentsDirectory()
-
-        // Save the video file
-        if let videoFilename = videoEntry.videoFilename {
-            do {
-                let videoEntryDirectory = try ensureVideoEntryDirectoryExists(for: videoFilename)
-                let videoDestURL = videoEntryDirectory.appendingPathComponent(videoFilename)
-                let transcriptURL = videoEntryDirectory.appendingPathComponent("transcript.md")
-                let cleanedTranscript = transcript?.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                // Copy the video file from temp location to documents directory
-                if fileManager.fileExists(atPath: videoDestURL.path) {
-                    try fileManager.removeItem(at: videoDestURL)
-                }
-                try fileManager.copyItem(at: tempURL, to: videoDestURL)
-                print("Successfully saved video: \(videoFilename)")
-
-                if let thumbnailImage = generateVideoThumbnail(from: videoDestURL) {
-                    persistThumbnail(thumbnailImage, for: videoFilename)
-                    print("Successfully saved thumbnail for video: \(videoFilename)")
-                } else {
-                    print("Could not generate thumbnail for video: \(videoFilename)")
-                }
-
-                // Create the metadata file
-                let metadataURL = documentsDirectory.appendingPathComponent(videoEntry.filename)
-                let metadataContent = "Video Entry"
-                try metadataContent.write(to: metadataURL, atomically: true, encoding: .utf8)
-
-                if let cleanedTranscript, !cleanedTranscript.isEmpty {
-                    try cleanedTranscript.write(to: transcriptURL, atomically: true, encoding: .utf8)
-                    print("Successfully saved transcript for video: \(videoFilename)")
-                } else if fileManager.fileExists(atPath: transcriptURL.path) {
-                    try fileManager.removeItem(at: transcriptURL)
-                }
-
-                let selectNewVideoEntry = {
-                    if let existingIndex = self.entries.firstIndex(where: { $0.id == videoEntry.id }) {
-                        self.entries[existingIndex] = videoEntry
-                    } else {
-                        self.entries.insert(videoEntry, at: 0)
-                    }
-                    self.entries.sort { self.isEntryNewer($0, than: $1) }
-                    guard let insertedEntry = self.entries.first(where: { $0.id == videoEntry.id }) else {
-                        print("Could not find saved video entry in entries array")
-                        return
-                    }
-                    self.selectedEntryId = insertedEntry.id
-                    self.currentVideoURL = videoDestURL
-                    self.text = ""
-                    self.didCopyTranscript = false
-                    self.selectedVideoHasTranscript = (cleanedTranscript?.isEmpty == false)
-                    print("Successfully loaded new video entry: \(videoFilename)")
-                    self.historyDebug("VIDEO SAVE selected \(self.debugEntrySummary(insertedEntry)) videoPath=\(videoDestURL.path)")
-                    self.logEntriesOrder("saveVideoEntry")
-                }
-                
-                if Thread.isMainThread {
-                    selectNewVideoEntry()
-                } else {
-                    DispatchQueue.main.async {
-                        selectNewVideoEntry()
-                    }
-                }
-
-                if replacementEntry != nil {
-                    print("Successfully replaced empty text entry with video entry")
-                } else {
-                    print("Successfully created video entry")
-                }
-            } catch {
-                print("Error saving video entry: \(error)")
-            }
-        }
-    }
-
     private func deleteEntry(entry: HumanEntry) {
         // Delete the file from the filesystem
         let documentsDirectory = getDocumentsDirectory()

--- a/freewrite/ContentView.swift
+++ b/freewrite/ContentView.swift
@@ -8,8 +8,6 @@
 
 import SwiftUI
 import AppKit
-import UniformTypeIdentifiers
-import PDFKit
 
 enum EntryType {
     case text
@@ -66,7 +64,6 @@ struct ContentView: View {
     @State private var hoveredEntryId: UUID? = nil
     @State private var showingSidebar = false  // Add this state variable
     @State private var hoveredTrashId: UUID? = nil
-    @State private var hoveredExportId: UUID? = nil
     @State private var placeholderText: String = ""  // Add this line
     @State private var isHoveringNewEntry = false
     @State private var isHoveringClock = false
@@ -892,50 +889,24 @@ struct ContentView: View {
 
                                                 Spacer()
                                                 
-                                                // Export/Trash icons that appear on hover
+                                                // Trash icon that appears on hover
                                                 if hoveredEntryId == entry.id {
-                                                    HStack(spacing: 8) {
-                                                        // Export PDF button
-                                                        Button(action: {
-                                                            exportEntryAsPDF(entry: entry)
-                                                        }) {
-                                                            Image(systemName: "arrow.down.circle")
-                                                                .font(.system(size: 11))
-                                                                .foregroundColor(hoveredExportId == entry.id ? 
-                                                                    (colorScheme == .light ? .black : .white) : 
-                                                                    (colorScheme == .light ? .gray : .gray.opacity(0.8)))
+                                                    Button(action: {
+                                                        deleteEntry(entry: entry)
+                                                    }) {
+                                                        Image(systemName: "trash")
+                                                            .font(.system(size: 11))
+                                                            .foregroundColor(hoveredTrashId == entry.id ? .red : .gray)
+                                                    }
+                                                    .buttonStyle(.plain)
+                                                    .onHover { hovering in
+                                                        withAnimation(.easeInOut(duration: 0.2)) {
+                                                            hoveredTrashId = hovering ? entry.id : nil
                                                         }
-                                                        .buttonStyle(.plain)
-                                                        .help("Export entry as PDF")
-                                                        .onHover { hovering in
-                                                            withAnimation(.easeInOut(duration: 0.2)) {
-                                                                hoveredExportId = hovering ? entry.id : nil
-                                                            }
-                                                            if hovering {
-                                                                NSCursor.pointingHand.push()
-                                                            } else {
-                                                                NSCursor.pop()
-                                                            }
-                                                        }
-                                                        
-                                                        // Trash icon
-                                                        Button(action: {
-                                                            deleteEntry(entry: entry)
-                                                        }) {
-                                                            Image(systemName: "trash")
-                                                                .font(.system(size: 11))
-                                                                .foregroundColor(hoveredTrashId == entry.id ? .red : .gray)
-                                                        }
-                                                        .buttonStyle(.plain)
-                                                        .onHover { hovering in
-                                                            withAnimation(.easeInOut(duration: 0.2)) {
-                                                                hoveredTrashId = hovering ? entry.id : nil
-                                                            }
-                                                            if hovering {
-                                                                NSCursor.pointingHand.push()
-                                                            } else {
-                                                                NSCursor.pop()
-                                                            }
+                                                        if hovering {
+                                                            NSCursor.pointingHand.push()
+                                                        } else {
+                                                            NSCursor.pop()
                                                         }
                                                     }
                                                 }
@@ -1155,171 +1126,6 @@ struct ContentView: View {
         } catch {
             print("Error deleting file: \(error)")
         }
-    }
-    
-    // Extract a title from entry content for PDF export
-    private func extractTitleFromContent(_ content: String, date: String) -> String {
-        // Clean up content by removing leading/trailing whitespace and newlines
-        let trimmedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        // If content is empty, just use the date
-        if trimmedContent.isEmpty {
-            return "Entry \(date)"
-        }
-        
-        // Split only the first line into words and remove punctuation
-        let firstLine = trimmedContent.components(separatedBy: .newlines).first ?? ""
-        let words = firstLine
-            .components(separatedBy: .whitespaces)
-            .filter { !$0.isEmpty }
-            .map { word in
-                word.trimmingCharacters(in: CharacterSet(charactersIn: ".,!?;:\"'()[]{}<>"))
-                    .lowercased()
-            }
-            .filter { !$0.isEmpty }
-        
-        // If we have at least 4 words, use them
-        if words.count >= 4 {
-            return "\(words[0])-\(words[1])-\(words[2])-\(words[3])"
-        }
-        
-        // If we have fewer than 4 words, use what we have
-        if !words.isEmpty {
-            return words.joined(separator: "-")
-        }
-        
-        // Fallback to date if no words found
-        return "Entry \(date)"
-    }
-    
-    private func exportEntryAsPDF(entry: HumanEntry) {
-        // First make sure the current entry is saved
-        if selectedEntryId == entry.id {
-            saveEntry(entry: entry)
-        }
-        
-        // Get entry content
-        let documentsDirectory = getDocumentsDirectory()
-        let fileURL = documentsDirectory.appendingPathComponent(entry.filename)
-        
-        do {
-            // Read the content of the entry
-            let entryContent = try String(contentsOf: fileURL, encoding: .utf8)
-            
-            // Extract a title from the entry content and add .pdf extension
-            let suggestedFilename = extractTitleFromContent(entryContent, date: entry.date) + ".pdf"
-            
-            // Create save panel
-            let savePanel = NSSavePanel()
-            savePanel.allowedContentTypes = [UTType.pdf]
-            savePanel.nameFieldStringValue = suggestedFilename
-            savePanel.isExtensionHidden = false  // Make sure extension is visible
-            
-            // Show save dialog
-            if savePanel.runModal() == .OK, let url = savePanel.url {
-                // Create PDF data
-                if let pdfData = createPDFFromText(text: entryContent) {
-                    try pdfData.write(to: url)
-                    print("Successfully exported PDF to: \(url.path)")
-                }
-            }
-        } catch {
-            print("Error in PDF export: \(error)")
-        }
-    }
-    
-    private func createPDFFromText(text: String) -> Data? {
-        // Letter size page dimensions
-        let pageWidth: CGFloat = 612.0  // 8.5 x 72
-        let pageHeight: CGFloat = 792.0 // 11 x 72
-        let margin: CGFloat = 72.0      // 1-inch margins
-        
-        // Calculate content area
-        let contentRect = CGRect(
-            x: margin,
-            y: margin,
-            width: pageWidth - (margin * 2),
-            height: pageHeight - (margin * 2)
-        )
-        
-        // Create PDF data container
-        let pdfData = NSMutableData()
-        
-        // Configure text formatting attributes
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = lineHeight
-        
-        let font = NSFont(name: selectedFont, size: fontSize) ?? .systemFont(ofSize: fontSize)
-        let textAttributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: NSColor(red: 0.20, green: 0.20, blue: 0.20, alpha: 1.0),
-            .paragraphStyle: paragraphStyle
-        ]
-        
-        // Trim the initial newlines before creating the PDF
-        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        // Create the attributed string with formatting
-        let attributedString = NSAttributedString(string: trimmedText, attributes: textAttributes)
-        
-        // Create a Core Text framesetter for text layout
-        let framesetter = CTFramesetterCreateWithAttributedString(attributedString)
-        
-        // Create a PDF context with the data consumer
-        guard let pdfContext = CGContext(consumer: CGDataConsumer(data: pdfData as CFMutableData)!, mediaBox: nil, nil) else {
-            print("Failed to create PDF context")
-            return nil
-        }
-        
-        // Track position within text
-        var currentRange = CFRange(location: 0, length: 0)
-        var pageIndex = 0
-        
-        // Create a path for the text frame
-        let framePath = CGMutablePath()
-        framePath.addRect(contentRect)
-        
-        // Continue creating pages until all text is processed
-        while currentRange.location < attributedString.length {
-            // Begin a new PDF page
-            pdfContext.beginPage(mediaBox: nil)
-            
-            // Fill the page with white background
-            pdfContext.setFillColor(NSColor.white.cgColor)
-            pdfContext.fill(CGRect(x: 0, y: 0, width: pageWidth, height: pageHeight))
-            
-            // Create a frame for this page's text
-            let frame = CTFramesetterCreateFrame(
-                framesetter, 
-                currentRange, 
-                framePath, 
-                nil
-            )
-            
-            // Draw the text frame
-            CTFrameDraw(frame, pdfContext)
-            
-            // Get the range of text that was actually displayed in this frame
-            let visibleRange = CTFrameGetVisibleStringRange(frame)
-            
-            // Move to the next block of text for the next page
-            currentRange.location += visibleRange.length
-            
-            // Finish the page
-            pdfContext.endPage()
-            pageIndex += 1
-            
-            // Safety check - don't allow infinite loops
-            if pageIndex > 1000 {
-                print("Safety limit reached - stopping PDF generation")
-                break
-            }
-        }
-        
-        // Finalize the PDF document
-        pdfContext.closePDF()
-        
-        return pdfData as Data
     }
 }
 

--- a/freewrite/ContentView.swift
+++ b/freewrite/ContentView.swift
@@ -78,6 +78,9 @@ struct ContentView: View {
     @State private var selectedVideoHasTranscript = false
     @State private var currentVideoURL: URL? = nil // Add state for current video being viewed
     let entryHeight: CGFloat = 40
+    private let editorInset: CGFloat = 18
+    // Extra clearance so the last line stays above the floating bottom nav.
+    private let bottomNavClearance: CGFloat = 50
     
     let placeholderOptions = [
         "Begin writing",
@@ -619,7 +622,6 @@ struct ContentView: View {
     
     var body: some View {
         let buttonBackground = colorScheme == .light ? Color.white : Color.black
-        let navHeight: CGFloat = 68
         let textColor = colorScheme == .light ? Color.gray : Color.gray.opacity(0.8)
         let textHoverColor = colorScheme == .light ? Color.black : Color.white
         let isViewingVideoEntry = currentVideoURL != nil
@@ -659,11 +661,11 @@ struct ContentView: View {
                                     .allowsHitTesting(false)
                             }
                         }
-                        .frame(maxWidth: 650, maxHeight: .infinity, alignment: .topLeading)
-                        .padding(.top, 40)
-                        .padding(.horizontal, 16)
-                        .padding(.bottom, bottomNavOpacity > 0 ? navHeight : 0)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                        // Fixed 18pt page inset; extra bottom clearance keeps text above the floating nav.
+                        .padding(.top, editorInset)
+                        .padding(.horizontal, editorInset)
+                        .padding(.bottom, editorInset + bottomNavClearance)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                         .id("\(selectedFont)-\(fontSize)-\(colorScheme)")
                         .colorScheme(colorScheme)
                         .onAppear {

--- a/freewrite/ContentView.swift
+++ b/freewrite/ContentView.swift
@@ -609,8 +609,14 @@ struct ContentView: View {
         }
 
         let firstLine = trimmedText.components(separatedBy: .newlines).first ?? trimmedText
-        let cleaned = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
-        return cleaned.isEmpty ? "Untitled" : cleaned
+        let words = firstLine
+            .components(separatedBy: .whitespaces)
+            .filter { !$0.isEmpty }
+        if words.isEmpty {
+            return "Untitled"
+        }
+        let title = words.prefix(4).joined(separator: " ")
+        return words.count > 4 ? "\(title)..." : title
     }
 
     

--- a/freewrite/freewriteApp.swift
+++ b/freewrite/freewriteApp.swift
@@ -192,8 +192,9 @@ struct freewriteApp: App {
                 .preferredColorScheme(colorSchemeString == "dark" ? .dark : .light)
         }
         // Native macOS title bar (traffic lights + centered window title)
-        .defaultSize(width: 1100, height: 600)
-        .windowResizability(.contentSize)
+        // Default is a comfortable note size; min allows Age-like compact windows.
+        .defaultSize(width: 360, height: 540)
+        .windowResizability(.contentMinSize)
     }
 }
 

--- a/freewrite/freewriteApp.swift
+++ b/freewrite/freewriteApp.swift
@@ -6,6 +6,173 @@
 //
 
 import SwiftUI
+import AppKit
+
+/// Keeps native traffic lights + title, but forces a solid title bar that
+/// always matches the note background (macOS likes to reset this on focus).
+enum WindowChrome {
+    private final class WindowState {
+        var title: String = "Untitled"
+        var isDark: Bool = false
+    }
+
+    private static var observations: [NSObjectProtocol] = []
+    private static var states = NSMapTable<NSWindow, WindowState>(
+        keyOptions: .weakMemory,
+        valueOptions: .strongMemory
+    )
+    private static var started = false
+
+    private static func state(for window: NSWindow) -> WindowState {
+        if let existing = states.object(forKey: window) {
+            return existing
+        }
+        let newState = WindowState()
+        states.setObject(newState, forKey: window)
+        return newState
+    }
+
+    static func startObserving() {
+        guard !started else { return }
+        started = true
+
+        let names: [Notification.Name] = [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didBecomeMainNotification,
+            NSWindow.didExposeNotification,
+            NSApplication.didBecomeActiveNotification,
+            NSApplication.didChangeScreenParametersNotification,
+        ]
+
+        for name in names {
+            let token = NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { notification in
+                if let window = notification.object as? NSWindow {
+                    apply(to: window)
+                } else {
+                    applyToAllWindows()
+                }
+            }
+            observations.append(token)
+        }
+    }
+
+    /// Called from SwiftUI when the entry title or theme changes for a specific window.
+    static func update(for window: NSWindow, title: String, isDark: Bool) {
+        guard shouldStyle(window) else { return }
+        let state = state(for: window)
+        let themeChanged = state.isDark != isDark
+        state.title = title
+        state.isDark = isDark
+
+        window.title = title
+        if themeChanged {
+            apply(to: window)
+        }
+    }
+
+    static func applyToAllWindows() {
+        for window in NSApplication.shared.windows where shouldStyle(window) {
+            apply(to: window)
+        }
+    }
+
+    static func apply(to window: NSWindow) {
+        guard shouldStyle(window) else { return }
+        let state = state(for: window)
+
+        window.title = state.title
+        window.styleMask.insert([.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView])
+        window.titleVisibility = .visible
+        window.titlebarAppearsTransparent = true
+        window.isOpaque = true
+        window.appearance = NSAppearance(named: state.isDark ? .darkAqua : .aqua)
+        window.backgroundColor = state.isDark ? .black : .white
+
+        if #available(macOS 11.0, *) {
+            window.titlebarSeparatorStyle = .none
+        }
+
+        // macOS re-injects a material fill into the title bar when key status changes.
+        // Clear it so the solid window / content color shows through.
+        clearTitlebarMaterials(in: window)
+
+        // Re-apply after the run loop so we win races against AppKit's own redraw.
+        DispatchQueue.main.async {
+            guard shouldStyle(window) else { return }
+            window.titlebarAppearsTransparent = true
+            window.backgroundColor = state.isDark ? .black : .white
+            if #available(macOS 11.0, *) {
+                window.titlebarSeparatorStyle = .none
+            }
+            clearTitlebarMaterials(in: window)
+        }
+    }
+
+    private static func shouldStyle(_ window: NSWindow) -> Bool {
+        // Style ordinary app windows; skip menus / status items if any.
+        window.contentView != nil && !window.className.contains("NSStatusBar")
+    }
+
+    private static func clearTitlebarMaterials(in window: NSWindow) {
+        guard let closeButton = window.standardWindowButton(.closeButton) else { return }
+
+        // closeButton → titlebar view → titlebar container
+        var view: NSView? = closeButton.superview
+        while let current = view {
+            neutralizeTitlebarMaterials(in: current)
+            if current.className.contains("TitlebarContainer") {
+                break
+            }
+            view = current.superview
+        }
+    }
+
+    private static func neutralizeTitlebarMaterials(in root: NSView) {
+        if let effectView = root as? NSVisualEffectView {
+            // Hidden effect views stop AppKit from painting the gray material strip.
+            effectView.isHidden = true
+            effectView.alphaValue = 0
+        }
+
+        root.wantsLayer = true
+        if root.className.contains("Titlebar") {
+            root.layer?.backgroundColor = NSColor.clear.cgColor
+        }
+
+        for subview in root.subviews {
+            neutralizeTitlebarMaterials(in: subview)
+        }
+    }
+}
+
+/// Pushes the current entry title + theme into WindowChrome and hooks window access.
+struct WindowTitleAccessor: NSViewRepresentable {
+    let title: String
+    let isDark: Bool
+
+    func makeNSView(context: Context) -> NSView {
+        WindowChrome.startObserving()
+        let view = NSView()
+        DispatchQueue.main.async {
+            if let window = view.window {
+                WindowChrome.update(for: window, title: title, isDark: isDark)
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            if let window = nsView.window {
+                WindowChrome.update(for: window, title: title, isDark: isDark)
+            }
+        }
+    }
+}
 
 @main
 struct freewriteApp: App {
@@ -22,12 +189,10 @@ struct freewriteApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .toolbar(.hidden, for: .windowToolbar)
                 .preferredColorScheme(colorSchemeString == "dark" ? .dark : .light)
         }
-        .windowStyle(.hiddenTitleBar)
+        // Native macOS title bar (traffic lights + centered window title)
         .defaultSize(width: 1100, height: 600)
-        .windowToolbarStyle(.unifiedCompact)
         .windowResizability(.contentSize)
     }
 }
@@ -35,6 +200,8 @@ struct freewriteApp: App {
 // Add AppDelegate to handle window configuration
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
+        WindowChrome.startObserving()
+
         if let window = NSApplication.shared.windows.first {
             // Ensure window starts in windowed mode
             if window.styleMask.contains(.fullScreen) {
@@ -43,6 +210,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             
             // Center the window on the screen
             window.center()
+            WindowChrome.apply(to: window)
         }
     }
-} 
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        WindowChrome.applyToAllWindows()
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the centered 650px editor column with a full-width writing area that uses a fixed 18pt inset on top and sides.
- Adds extra bottom clearance so the last line stays visible above the floating bottom nav instead of being clipped underneath it.
- Updates `DESIGN.md`, `AGENTS.md`, and `CLAUDE.md` to document the new full-bleed editor layout.

## Test plan
- [ ] Open a text entry and confirm text starts 18pt from the top and side edges at any window width
- [ ] Type enough lines to reach the bottom and confirm the last line scrolls fully into view above the nav bar
- [ ] Verify the placeholder aligns with the first line of text in an empty entry
- [ ] Resize the window wide and confirm the editor grows with it (no 650px cap)

Made with [Cursor](https://cursor.com)